### PR TITLE
chore(spec): re-vendor 1.86.0; document the split write constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this module are documented here, in
 
 ## [Unreleased]
 
+### Changed
+
+- Re-vendored `openapi.yaml` from the live YNAB spec. Upstream amended one
+  description — `SaveTransactionWithOptionalFields.subtransactions`, the
+  shared save-transaction schema — without bumping the spec version, which
+  stays 1.86.0. No path, field, type, or enum moved, so the public surface is
+  unchanged and no upgrade action is needed.
+- Documented the two split-write rules the amended description states, on
+  `TransactionSpec.Splits` and `TransactionUpdate`: the API rejects splits on
+  tracking accounts and on transfers between on-budget accounts (a transfer
+  *to* a tracking account may be split), and updating the subtransactions of
+  an existing split transaction returns an error. Both are enforced by the
+  server: the write payload does not carry account type, so the
+  tracking-account rule cannot be checked before the request; the update rule
+  is structurally unreachable — `TransactionUpdate` carries no split legs.
+  Godoc only; no behavior change.
+
 ## [1.6.1] - 2026-07-21
 
 ### Added

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2905,7 +2905,9 @@ components:
           type: array
           description: An array of subtransactions to configure a transaction as a split.
             Updating `subtransactions` on an existing split transaction is not
-            supported.
+            supported and will return an error.  Splits are not allowed on
+            tracking accounts or on transfers between on-budget accounts; a
+            transfer to a tracking account can be a split.
           items:
             $ref: "#/components/schemas/SaveSubTransaction"
     SaveSubTransaction:

--- a/transactions.go
+++ b/transactions.go
@@ -372,6 +372,11 @@ type TransactionSpec struct {
 	// "YNAB:<milliunits>:<date>:<n>".
 	ImportID Optional[string] `json:"import_id,omitzero"`
 
+	// Splits carries the legs of a split transaction. The API rejects
+	// splits on tracking accounts and on transfers between on-budget
+	// accounts; a transfer to a tracking account may be split. Account
+	// type is not part of this payload, so the server enforces that —
+	// this package cannot.
 	Splits []SubtransactionSpec `json:"subtransactions,omitzero"`
 }
 
@@ -495,6 +500,10 @@ func (s *TransactionsService) CreateBatch(ctx context.Context, specs []Transacti
 // [TransactionsService.Update] and the patches built by
 // [PatchByID]/[PatchByImportID]. Unset fields stay unchanged on the
 // server; [SetNull] clears.
+//
+// This package sets splits at creation only, through [TransactionSpec]:
+// the API does not support updating subtransactions on an existing split
+// transaction and answers with an error.
 type TransactionUpdate struct {
 	AccountID Optional[string]     `json:"account_id,omitzero"`
 	Date      Optional[Date]       `json:"date,omitzero"`


### PR DESCRIPTION
Closes the G6 spec-drift alarm that went red on run #4 (2026-08-07 02:40Z): `live OpenAPI spec drifted from the vendored 1.86.0 pin`.

## What changed

YNAB amended one `description` in the live OpenAPI spec — `SaveTransactionWithOptionalFields.subtransactions` — **without bumping `info.version`**, which stays 1.86.0. The vendored pin is refreshed to match, byte for byte, and the two rules the new prose states are documented on the write surface.

```
Updating `subtransactions` on an existing split transaction is not
supported and will return an error.  Splits are not allowed on
tracking accounts or on transfers between on-budget accounts; a
transfer to a tracking account can be a split.
```

## Evidence

- `git diff --numstat openapi.yaml` = `3 1`. Parsing both revisions and walking them yields **one** semantic difference, at `$.components.schemas.SaveTransactionWithOptionalFields.properties.subtransactions.description`. With `description` keys stripped, both documents hash identically.
- `servers`, top-level `security`, and `components.securitySchemes` are unchanged; all 31 paths, 44 operations, 96 schemas and 201 `$ref`s compare equal. No operation carries a `security` override, so the auth model is provably untouched.
- The vendored file is byte-identical to the live spec (`sha256 da7a7834…`).
- `transactions.go` is comments-only: parsing both revisions with comments stripped and re-printing gives an identical AST hash (`81dd5f6b…`). `apidiff` passes against the `v1.6.1` baseline, confirming mechanically that the public surface did not move.

## Deliberately unchanged

- **`SpecVersion`** stays `1.86.0` and still matches the file.
- **No validation.** The tracking-account rule is undecidable client-side: the write payload carries only `AccountID`, account type lives on the read model, and the transfer counterparty is a `transfer_payee_id` rather than an account id. `TransactionSpec.validate` is documented as applying the spec-stated invariants and only those. The update rule is already structurally impossible — `TransactionUpdate` declares no split legs.
- **No `API_NOTES.md` entry.** That ledger is scoped to undocumented or divergent-in-practice behavior; this is upstream documenting what it had omitted. No divergence, no workaround.
- **No `SPEC.md` amendment.** The public surface did not move.
- **No new test.** No offline gate parses spec descriptions — the scanner's visible token stream is byte-identical across the refresh (375 lines both sides). The new `spec_conformance_live_test.go` is also unaffected: loaded under the pinned `kin-openapi v0.144.0`, the descriptions-stripped documents are deep-equal, and the amended schema is reachable only as a request body while that test validates responses only.

## Gates

`make local-ci` exit 0 — lint, examples, `test -race`, contract, govulncheck, tidy-check, actionlint, check-version-selftest, apidiff, apidiff-selftest, coverage **97.1%** (unchanged from the pre-change baseline).

## Review disclosure

The ship fan-out ran on **Opus 5, not Fable**. Fable was exhausted mid-run and the substitution was explicitly signed off, so these reviews are not comparable with earlier ship runs. The change was reviewed three times: a first pass returned REQUEST CHANGES on three prose claims (all fixed), a second pass returned 3/3 GO, and after this work was replayed onto current `main` — the original branch was orphaned when its remote was deleted — a third full fan-out on the final bytes returned 3/3 GO.

## Known gaps, out of scope here

This commit is the empirical proof of the first one:

1. The vendored spec has **no content pin**, so a same-version upstream edit cannot fail any gate. A tracked `sha256` asserted in the contract test would close it.
2. The contract gate covers nothing below `components.schemas` — mutation testing showed a renamed write field, a tightened `maxLength`, an added enum value, and even deleting `subtransactions` entirely all pass green.
3. `make update-spec` passes `-L`, which follows cross-host HTTPS redirects, and lacks `--remove-on-error`, so a partial download would be vendored silently.