### PR TITLE
chore(spec): harden the update-spec fetch

### DIFF
--- a/.github/workflows/drift.yaml
+++ b/.github/workflows/drift.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: fetch live spec    # local equivalent: the update-spec curl, into a temp file
         run: |
-          curl --proto '=https' --tlsv1.2 --max-time 60 -fsSL \
+          curl --proto '=https' --tlsv1.2 --max-time 60 -fsS --remove-on-error \
             https://api.ynab.com/papi/open_api_spec.yaml -o /tmp/live_spec.yaml
 
       - name: diff against vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ All notable changes to this module are documented here, in
   is structurally unreachable — `TransactionUpdate` carries no split legs.
   Godoc only; no behavior change.
 
+### Security
+
+- Hardened the fetch that vendors `openapi.yaml`, in `make update-spec` and in
+  the drift workflow that mirrors it. Dropped `-L`: the endpoint answers 200
+  with zero redirects, and following one would let whatever host a `Location`
+  header names supply the bytes — measured against a local server, `-fsSL`
+  silently vendors a cross-host redirect's body. Added `--remove-on-error`, so
+  a partial download is deleted rather than left on disk as truncated YAML
+  (also measured), which matters because every operation and the version line
+  precede `components:`, so a body cut there still scans as 44 valid ops and
+  passes every offline gate. Added `--max-time` to match the workflow.
+  No code, API, or behavior change; the vendored spec this fetch writes ships
+  inside the module zip, so its provenance is part of the release supply chain.
+
 ## [1.6.1] - 2026-07-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,18 @@ vulncheck:
 # update-spec overwrites the pinned vendored spec (1.86.0) with today's live
 # spec. If run before a release: restore with `git checkout -- openapi.yaml`
 # and re-assert `version: 1.86.0` — re-vendoring is an ask-first change.
+#
+# The fetch flags are supply-chain controls on an artifact that ships inside
+# the module zip. --proto '=https' pins the scheme, --tlsv1.2 sets a floor,
+# -f keeps a 4xx/5xx error page off disk, and --max-time mirrors drift.yaml.
+# No -L: the endpoint answers 200 directly, and following a redirect would
+# let whatever host a Location names supply the bytes. --remove-on-error
+# deletes a partial download — every operation and the version line precede
+# components:, so a body cut there still scans as 44 valid ops and passes
+# every offline gate.
 update-spec:
-	curl --proto '=https' --tlsv1.2 -fsSL https://api.ynab.com/papi/open_api_spec.yaml -o openapi.yaml
+	curl --proto '=https' --tlsv1.2 --max-time 60 -fsS --remove-on-error \
+		https://api.ynab.com/papi/open_api_spec.yaml -o openapi.yaml
 	git diff --stat openapi.yaml
 
 # -count=1: live-API runs must never be served from the test cache.


### PR DESCRIPTION
Gap 3 of 3 from #49's "known gaps" list. Tooling only — no Go file, no module graph, no public surface.

## The change

```diff
-curl --proto '=https' --tlsv1.2 -fsSL <url> -o openapi.yaml
+curl --proto '=https' --tlsv1.2 --max-time 60 -fsS --remove-on-error <url> -o openapi.yaml
```

Applied identically in `make update-spec` and in `.github/workflows/drift.yaml`, which its own comment calls this recipe's local equivalent. The two now differ only in the `-o` path.

`openapi.yaml` is not just a local file: it ships inside the module zip — **1 of 194 files** in `pkg.venceslau.dev/ynab@v1.6.1`, verified against `proxy.golang.org`. Its provenance is part of the release supply chain.

## Measured, not argued

Every claim below came from a local probe server, not the man page.

| Case | `-fsSL` (before) | `-fsS --remove-on-error` (after) |
|---|---|---|
| cross-host 302 | exit 0, **attacker payload vendored** | exit 0, the 302's own body |
| 4xx/5xx | exit 22, no file | exit 22, no file *(`-f` already covered this)* |
| truncated mid-stream | exit 18, **partial prefix left on disk** | exit 18, **file deleted** |

**Truncation is the worse of the two gaps.** Every `operationId` and the `version` line precede `components:` — the last `operationId` begins at byte 65,406 and its line completes by 65,445, while `components:` begins at 66,456 of 135,272. So a body cut anywhere past 49% still scans as exactly 44 operations and satisfies `contract_test.go:30`'s `require.Len(spec.Ops, 44)`. Confirmed by truncating the real spec to 53% of its bytes: `make local-ci` stays green end to end. The only *test* that rejects it is the integration conformance test, which parses the file through kin-openapi.

## What dropping `-L` does and does not buy

It does **not** neutralize an injected redirect. The attacker chooses the 302's body too, and curl writes it. A spec with an injected `servers:` entry still passes the contract gate — reconstructed and measured: 44 ops, 13 bodies, 11 deltas, empty `DiffSpec` — because the scanner matches only path, verb, `operationId`, parameter, `version`, `requestBody` and `responses` lines, and a `servers:` url matches none of them.

What it buys is narrower and real: the bytes must come from a peer presenting a valid `api.ynab.com` certificate, instead of any host a `Location` header names.

## Known residue, filed separately

Disclosed rather than hidden:

1. A cross-host 302 still replaces `openapi.yaml` and `make update-spec` exits 0, because a 302 is not an error under `-f`. CI catches it; the local recipe does not. → shape-check the fetch before it replaces the tracked file.
2. Nothing asserts these flags, so a future edit could restore `-L` unopposed. → a grep gate over every fetch site.

`SPEC.md` §8 documented the old `-fsSL` recipe; it now points at the Makefile instead of restating flags, matching the altitude of its sibling rows. That file is gitignored, so the fix is local-only and not in this diff.

## Gates

`make local-ci` exit 0 — lint, examples, `test -race`, contract, govulncheck, tidy-check, actionlint, apidiff, apidiff-selftest, check-version-selftest, coverage **97.1%** (unchanged).

## Review disclosure

Ship fan-out ran on **Opus 5, not Fable** (Fable exhausted; substitution explicitly signed off), so these reviews are not comparable with earlier ship runs. Three rounds were needed, and each found a real defect in my own prose, not in the flags:

1. `SPEC.md:575` still carried the removed recipe — flagged by 3/3 personas; the commit had not completed its own declared scope.
2. The CHANGELOG claimed "the module is untouched" — **false**, `openapi.yaml` ships in the zip.
3. The stated *cause* of the truncation hole was wrong: I wrote that the scanner "only fails at ZERO operations", but the binding assertion is an exact `require.Len(..., 44)`. A maintainer following my wording would have tightened the wrong thing.