### PR TITLE
test(contract): pin the vendored spec by content

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# openapi.yaml is pinned by content (contract.SpecSHA256), so its bytes must
+# survive checkout unchanged. Without this, a clone with core.autocrlf=true
+# materializes CRLF and fails the pin while every other gate stays green —
+# and `git checkout -- openapi.yaml` re-applies the conversion, so the
+# obvious remedy loops. CI is Linux-only and would never surface it.
+openapi.yaml -text
+
+# The shell gates are executed, not just read: check-version.sh is the
+# release gate and both apidiff scripts run in local-ci. Under the same
+# CRLF checkout, all three fail `bash -n` (measured: 43, 78 and 148 CRs)
+# with a syntax error in a file nobody edited. eol=lf, not -text, so a
+# script committed with CRLF is normalized rather than preserved.
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ All notable changes to this module are documented here, in
   passes every offline gate. Added `--max-time` to match the workflow.
   No code, API, or behavior change; the vendored spec this fetch writes ships
   inside the module zip, so its provenance is part of the release supply chain.
+- Pinned `openapi.yaml` by content: `contract.SpecSHA256`, asserted by a new
+  contract test. The version pin could not do this — upstream amends the spec
+  in place without moving `info.version`, exactly as it did earlier in this
+  same `[Unreleased]` block. Measured before the pin: a hostile `servers:` url,
+  a `maxLength` tightened from 500 to 50, an amended description, a body
+  truncated to 53% of its bytes, and a single appended newline each passed
+  every offline gate; all five now fail. Re-vendoring becomes two edits in
+  one commit — the spec and the constant — which is the deliberate act the
+  project already required but could not enforce. The assertion is test-only
+  and the constant lives in `internal/`, so no public surface moved.
 
 ## [1.6.1] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,12 @@ are missing.
   same PR.
 - **Do not run `make update-spec`** casually — it overwrites the pinned
   vendored spec. If you did: `git checkout -- openapi.yaml`. Re-vendoring is
-  ask-first.
+  ask-first, in any amount — description-only counts. A deliberate re-vendor
+  is two edits in one commit: the spec, and `contract.SpecSHA256` in
+  `internal/contract/table.go`, which pins it by content. `make contract`
+  fails and prints the replacement digest. Review the whole spec diff before
+  you paste it — the digest proves the bytes were declared, not that anyone
+  read them.
 
 ## Which tests does my change need?
 

--- a/contract_test.go
+++ b/contract_test.go
@@ -5,6 +5,8 @@
 package ynab_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -31,6 +33,27 @@ func TestContractSpecDiff(t *testing.T) {
 	require.Len(t, contract.Table(), 44)
 
 	require.Empty(t, contract.DiffSpec(contract.Table(), spec))
+}
+
+// TestContractSpecContent pins the vendored spec by content; see
+// [contract.SpecSHA256] for why the version pin cannot. The version and
+// operation-count pins catch a re-vendor only when it moves those; this is
+// the one assertion that fires on every re-vendor, including the
+// description-only kind upstream has already shipped once.
+func TestContractSpecContent(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("openapi.yaml")
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(raw)
+	require.Equal(t, contract.SpecSHA256, hex.EncodeToString(sum[:]),
+		"vendored openapi.yaml does not match its pin.\n"+
+			"If update-spec ran by accident: git checkout -- openapi.yaml\n"+
+			"If this is a deliberate re-vendor: review the whole spec diff,\n"+
+			"description-only included, then set contract.SpecSHA256 to the\n"+
+			"actual value above, in this commit. See CONTRIBUTING.md;\n"+
+			"re-vendoring is ask-first.")
 }
 
 // TestContractDocLines scans the root package for `// YNAB operationId:`

--- a/internal/contract/table.go
+++ b/internal/contract/table.go
@@ -31,6 +31,22 @@ type Operation struct {
 // update-spec run cannot slip through.
 const SpecVersion = "1.86.0"
 
+// SpecSHA256 pins the vendored openapi.yaml by content, not by name.
+// SpecVersion alone cannot do that: upstream amends the spec in place
+// without moving info.version — it did exactly that in 1.86.0, editing a
+// description while the version string stayed put. No offline gate covers
+// anything below components: either; only the live conformance layer (G8,
+// build tag integration) validates against those schemas, and it needs a
+// token. Without this pin a renamed write field, a tightened maxLength, a
+// new enum value, or a body truncated past the last operationId (every
+// operationId precedes components:, so the 44-operation count still holds)
+// would reach main unopposed on a PR.
+//
+// Re-vendoring therefore becomes two edits in one commit — the spec and
+// this constant — which a reviewer sees together. The test prints the
+// replacement digest on mismatch; see CONTRIBUTING.md for the rule.
+const SpecSHA256 = "da7a78345b34b0fa6e50c39709cf860cb869c70d137d506c925d8b1886f3a98b"
+
 // Table returns all 44 rows of the coverage contract, transcribed from the
 // frozen public surface. Query parameters mirror the vendored spec.
 func Table() []Operation {


### PR DESCRIPTION
Gap 1 of the three named in #49. Closes the last one: the vendored spec had no content identity.

## The problem, demonstrated by this repo's own history

`SpecVersion` pins `openapi.yaml` by **name**. Upstream amends the spec in place without moving `info.version` — #49 was exactly that: a description edited while the version string stayed `1.86.0`. So the one assertion guarding the file could not fire on a content change.

No offline gate covered the gap. G1's `ScanSpec` matches seven line shapes — path, verb, `operationId`, parameter name/in, `version`, `requestBody`, `responses`. All sit above `components:`, but they are far from everything above it: `servers:`, `security:`, `tags:`, the summaries and `$ref`s inside `paths:`, and the parameter schemas themselves are unread too. Below `components:` it reads **nothing at all**.

## Measured before the pin — every one of these passed every offline gate

| Mutation | Now |
|---|---|
| `servers[0].url` → hostile host | fails |
| `$ref` retargeted; `securitySchemes` bearer → basic | fails |
| `maxLength` 500 → 50 on a write field | fails |
| a write field renamed; a new enum value added | fails |
| the real upstream edit (`…subtransactions.description`) | fails |
| body truncated to 53% — every `operationId` precedes `components:`, so `require.Len(spec.Ops, 44)` still held | fails |
| a single appended newline | fails |

In every case the content pin is the **only** failing test.

## Design

`SpecSHA256` sits beside `SpecVersion` so the two read as one pin, and the assertion is a contract test so `make contract` and CI carry it.

**Deliberately not wired into `make update-spec`.** A recipe that regenerated the digest would satisfy the gate on every re-vendor and assert nothing. The human updates the constant, or the gate stays red. That makes the digest a tripwire, not proof of review — so CONTRIBUTING now says reviewing the whole spec diff is part of the act, unconditionally, and where the replacement digest comes from.

## `.gitattributes`

`openapi.yaml -text`. Content-hashing a tracked text file makes it checkout-sensitive, and this PR is what introduces that: measured, a `core.autocrlf=true` checkout produced **139,303** bytes instead of 135,272 and failed the pin while every other gate stayed green — and the failure message's own first remedy, `git checkout -- openapi.yaml`, would re-apply the conversion and loop. CI is Linux-only and would never surface it. `-text` rather than `eol=lf`, because normalizing on check-in would rewrite vendored bytes and make the digest unreproducible against the fetch.

The same file marks `*.sh text eol=lf` — a **pre-existing break** the CRLF probe exposed. `check-version.sh` (the release gate) and both apidiff scripts (in `local-ci`) fail `bash -n` under that checkout, with 43, 78 and 148 stray CRs. A Windows contributor would have hit a syntax error in a file nobody edited.

## Gates

`make local-ci` exit 0 — lint, examples, `test -race`, contract, govulncheck, tidy-check, actionlint, apidiff, apidiff-selftest, check-version-selftest, coverage **97.1%** (unchanged). Test-only; the constant lives in `internal/`, and apidiff output is byte-identical to base.

## Review disclosure

Fan-out on **Opus 5, not Fable** (Fable exhausted; substitution signed off), so not comparable with earlier ship runs. **Four rounds**, each finding a real defect in my prose rather than the mechanism:

1. The failure message pointed at `SPEC.md` — untracked, absent from a fresh clone and from the Actions checkout — and cited a §11 rule narrower than the gate, which actively licensed skipping a description-only diff.
2. No `.gitattributes`, so the pin was line-ending sensitive and its own remedy looped.
3. A godoc claim that "nothing below `components:` is otherwise gated" — false; G8 validates against those schemas.
4. A parenthetical asserting four items all precede `components:` — false for three of them; only truncation is about that.