### PR TITLE
ci: split the go-drift watch out of spec-drift

### DIFF
--- a/.github/workflows/drift.yaml
+++ b/.github/workflows/drift.yaml
@@ -1,9 +1,12 @@
-# G6 — the weekly drift watches. Spec: fetch the live OpenAPI spec and
-# diff against the vendored pin; on drift the job FAILS (red badge) and
-# uploads the diff as an artifact. Go: fail when go.dev lists a newer
-# stable than the workflows pin. Both alarms are red-only — re-vendoring
-# and toolchain bumps are deliberate human changes, never automated (and
-# this repository's workflow opens no automatic PRs).
+# G6 — the weekly spec-drift watch: fetch the live OpenAPI spec and diff
+# against the vendored pin; on drift the job FAILS (red badge) and uploads
+# the diff as an artifact. Red-only — re-vendoring is a deliberate human
+# change, never automated (and this repository opens no automatic PRs).
+#
+# This workflow watches the spec and nothing else. Its toolchain twin lives
+# in go-drift.yaml: a status badge reports the RUN conclusion, so while
+# the two shared a file a stale Go pin turned the spec-drift badge red with
+# the vendored spec perfectly current.
 # Actions are SHA-pinned (tag in the comment); bump deliberately.
 name: spec-drift
 
@@ -43,14 +46,3 @@ jobs:
         with:
           name: spec-diff
           path: spec.diff
-
-  go-version:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: make go-latest-check
-        run: make go-latest-check

--- a/.github/workflows/go-drift.yaml
+++ b/.github/workflows/go-drift.yaml
@@ -1,0 +1,37 @@
+# G6's toolchain half: fail when go.dev lists a stable newer than the
+# newest version pinned in the workflows, so the matrices never silently
+# go stale. Red-only — bumping the toolchain is a deliberate human change,
+# and this repository opens no automatic PRs.
+#
+# Split out of spec-drift deliberately. A workflow status badge reports the
+# RUN conclusion, so while these shared a file a stale Go pin turned the
+# spec-drift badge red with the vendored spec perfectly current — the badge
+# asserted the wire contract had moved when it had not. One alarm per
+# workflow keeps each signal readable from the outside.
+#
+# Named for the condition, not the subject, matching spec-drift: `go-version`
+# would collide with the setup-go input key of the same name, which five
+# other files use to mean "which Go we build with" — including the very pin
+# that go-latest-check tells you to bump.
+# Actions are SHA-pinned (tag in the comment); bump deliberately.
+name: go-drift
+
+on:
+  schedule:
+    - cron: '29 6 * * 1' # weekly, Monday 06:29 UTC — between drift and smoke
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: make go-latest-check
+        run: make go-latest-check

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,7 +9,7 @@ name: integration
 
 on:
   schedule:
-    - cron: '11 7 * * 1' # weekly, Monday 07:11 UTC — after drift and smoke
+    - cron: '11 7 * * 1' # weekly, Monday 07:11 UTC — last of the weekly watches
   workflow_dispatch:
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,10 @@ apidiff-selftest:
 # Everything the CI's full leg runs, locally — burn zero Actions minutes.
 local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest apidiff apidiff-selftest coverage
 
-# The toolchain twin of the spec-drift watch: fails when go.dev lists a
-# newer stable Go than the newest one pinned in the workflows, so the
-# matrix never silently goes stale. Bumping stays a deliberate act.
+# The check behind .github/workflows/go-drift.yaml, which runs it weekly:
+# fails when go.dev lists a newer stable Go than the newest one pinned in
+# the workflows, so the matrix never silently goes stale. Bumping stays a
+# deliberate act.
 go-latest-check:
 	@latest=$$(curl --proto '=https' --tlsv1.2 --max-time 30 -fsSL 'https://go.dev/dl/?mode=json' \
 		| sed -n 's/^ *"version": *"go\([0-9]*\.[0-9]*\)[.0-9]*",$$/\1/p' | head -1); \


### PR DESCRIPTION
Prerequisite for #53 (the spec-drift badge). Opened separately because the badge is only honest once this lands.

## The problem

`drift.yaml` carried two unrelated alarms: the spec diff (G6) and `go-latest-check`, which fails when go.dev lists a stable newer than the workflows pin. The file's own header called them *"the weekly drift watches"*, plural — the admission that they were never one thing.

A workflow status badge reports the **run** conclusion, so a badge on this workflow goes red if either job fails. Go cuts a stable roughly every six months; on the Monday after, `go-latest-check` exits 1 and a badge reading **spec-drift** turns red while `openapi.yaml` is byte-identical to the live spec — asserting the wire contract had moved when it had not. Nothing re-runs the workflow on push, so the false red would persist until someone noticed.

## The change

One alarm per workflow. The moved job's steps are byte-identical — same runner, timeout, SHA-pinned checkout with `persist-credentials: false`, workflow-level `contents: read`. Only the job id changes (`go-version` → `check`), since the workflow name now carries the meaning.

**Named `go-drift`, for the condition rather than the subject**, matching `spec-drift`. `go-version` was wrong in a specific way: it is already the `setup-go` input key in `ci.yaml`, `smoke.yaml`, `integration.yaml` and `release.yaml`, plus a field id in the bug template — five sites where it means "which Go we build with". `go-latest-check`'s own error text says to bump *"go-version in release.yaml"*, so a maintainer hitting that error would have opened `go-version.yaml` and not found the pin.

Cron moves to 06:29, keeping the staggered weekly slots the other watches use (drift 06:17, smoke 06:43, integration 07:11) instead of colliding with drift on the same minute. `integration.yaml`'s comment enumerated those watches and no longer could, so it names its position instead.

## Known, filed as a follow-up

`drift.yaml`'s fetch step has no retry, so an unreachable `api.ynab.com` still fails the run and reddens the badge with the spec current. Same class as the bug this PR fixes, but transient and self-healing on the next run rather than persistent. Fix would be `--retry 3 --retry-all-errors` plus a `::warning::`-and-`exit 0` path so only the diff step can go red. Flagging it as a conscious decision, not an oversight.

## Gates

`make local-ci` exit 0 including actionlint; `make go-latest-check` exit 0. No Go file, no module byte. No CHANGELOG line — CONTRIBUTING scopes that to user-visible changes.

## Review disclosure

Fan-out on **Opus 5, not Fable** (Fable exhausted; substitution signed off). Two rounds. The first returned GO but argued the rename with the five collision sites above, plus a trailing blank line, a Makefile comment claiming a symmetry that did not exist, and the cron collision — all applied here.