### PR TITLE
docs(readme): add the spec-drift badge, move CI to the native form

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/pkg.venceslau.dev/ynab.svg)](https://pkg.go.dev/pkg.venceslau.dev/ynab)
 [![CI](https://img.shields.io/github/actions/workflow/status/brunovenceslau/ynab.go/ci.yaml?branch=main&label=ci)](https://github.com/brunovenceslau/ynab.go/actions/workflows/ci.yaml)
+[![spec-drift](https://github.com/brunovenceslau/ynab.go/actions/workflows/drift.yaml/badge.svg)](https://github.com/brunovenceslau/ynab.go/actions/workflows/drift.yaml)
 [![License](https://img.shields.io/badge/license-BSD--2--Clause-blue)](LICENSE)
 
 A complete Go client for the [YNAB API v1](https://api.ynab.com): all 44

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # YNAB for Go
 
 [![Go Reference](https://pkg.go.dev/badge/pkg.venceslau.dev/ynab.svg)](https://pkg.go.dev/pkg.venceslau.dev/ynab)
-[![CI](https://img.shields.io/github/actions/workflow/status/brunovenceslau/ynab.go/ci.yaml?branch=main&label=ci)](https://github.com/brunovenceslau/ynab.go/actions/workflows/ci.yaml)
+[![ci](https://github.com/brunovenceslau/ynab.go/actions/workflows/ci.yaml/badge.svg)](https://github.com/brunovenceslau/ynab.go/actions/workflows/ci.yaml)
 [![spec-drift](https://github.com/brunovenceslau/ynab.go/actions/workflows/drift.yaml/badge.svg)](https://github.com/brunovenceslau/ynab.go/actions/workflows/drift.yaml)
 [![License](https://img.shields.io/badge/license-BSD--2--Clause-blue)](LICENSE)
 


### PR DESCRIPTION
Replaces #53, which GitHub auto-closed one second after #52 merged: #53 was stacked on `ci/split-go-version-watch`, and deleting that branch on merge closes any PR based on it. Same two commits, rebased onto `main`; nothing about the change was reconsidered.

Two badge changes, one line each.

## 1. Add the spec-drift badge

The G6 drift watch tells a reader whether the vendored OpenAPI spec still matches YNAB's live one. It had no badge, so the most decay-prone property of this library — that its wire contract is current — was invisible from the README. It is also the one property a consumer **cannot check themselves**: they have no way to diff YNAB's live spec against our vendored pin.

This is why #52 landed first. A status badge reports the **run** conclusion, and until #52 `drift.yaml` also ran the Go toolchain check — so this badge would have turned red whenever the Go pin went stale, asserting the wire contract had moved while `openapi.yaml` was byte-identical to live. The badge is only honest because `drift.yaml` now watches the spec and nothing else.

## 2. Move the CI badge to the native form

```diff
-[![CI](https://img.shields.io/github/actions/workflow/status/.../ci.yaml?branch=main&label=ci)](...)
+[![ci](https://github.com/brunovenceslau/ynab.go/actions/workflows/ci.yaml/badge.svg)](...)
```

**The gain is integrity, not privacy.** shields.io was a trusted intermediary re-rendering a security-relevant signal: it queries the GitHub API and draws its own picture, so a compromised or spoofed shields.io could render "passing" over a failing build. The native badge is served by the authority that computes the status.

It does **not** remove shields.io from the README — the License badge still resolves there, so every pkg.go.dev render still contacts that host, and the badge row now touches three image origins where it touched two. The License badge stays because it is a static literal, not a status readout, and GitHub offers no native equivalent.

**The dropped `?branch=main` is not a regression, verified rather than assumed.** `ci.yaml` runs on `pull_request` as well as `push: [main, v1]`, so an in-flight red PR must not colour the README. GitHub reports the default branch unless told otherwise, and across **all 74** `ci.yaml` runs every one attributed to `main` is a push run — PR runs carry their head branch. Both URL forms were fetched and are byte-identical, same sha256.

Label is lowercase `ci` to match the workflow's `name:` — the native badge renders that name and cannot be overridden, so alt text and image now agree.

## Verified live

Both SVGs return 200 `image/svg+xml` with zero redirects; both link targets return 200; every URL is `https://github.com` under this repo's own slug, pure ASCII. The spec-drift badge currently reads "passing".

## Gates

`make local-ci` exit 0 on the rebased branch, coverage 97.1%. README.md only — 2 insertions, 1 deletion. No CHANGELOG line: CONTRIBUTING scopes that to user-visible changes, and a status image alters no behavior, API, or output.

## Follow-ups filed, not fixed here

- `drift.yaml`'s fetch has no retry: an unreachable `api.ynab.com` reddens this badge with the spec current. Same class as the bug #52 fixed, but transient and self-healing on the next run.
- `?event=push` on the native badges would close a residual case (a PR whose *head* branch is `main`). Measured zero occurrences across 74 runs, and the old shields.io URL carried the identical exposure — hardening, not a regression.

## Review disclosure

Fan-out on **Opus 5, not Fable** (Fable exhausted; substitution signed off). The first round returned REQUEST CHANGES and is why #52 exists. The second round caught a false claim in my own commit message — I had written that this "drops a third-party host from the README", which the License badge disproves; the message now states the integrity argument instead.