### PR TITLE
test(contract): pin the transcribed wire constants to the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ All notable changes to this module are documented here, in
   one commit — the spec and the constant — which is the deliberate act the
   project already required but could not enforce. The assertion is test-only
   and the constant lives in `internal/`, so no public surface moved.
+- Pinned the transcribed wire constants to the spec they came from. The five
+  `maxLength` constants and the five string-enum sets were copied out of
+  `openapi.yaml` by hand and, until now, nothing checked they still matched:
+  the content pin notices that the spec moved, but a maintainer who reviews
+  the diff and re-pins the digest can still leave a stale bound behind, and
+  the client would go on rejecting payloads the server accepts. Two contract
+  tests now diff both, in both directions — a changed value fails on
+  comparison, and a bound or enum upstream *adds* fails on completeness,
+  which is the case a value check can never see. Mutation-tested: a
+  `maxLength` moved, an enum value added, one removed, a new unmapped bound,
+  and either Go side edited — six for six. Test-only; no public surface.
 
 ## [1.6.1] - 2026-07-21
 

--- a/contract_wire_test.go
+++ b/contract_wire_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Bruno Venceslau. All rights reserved.
+// Use of this source code is governed by a BSD-2-Clause
+// license that can be found in the LICENSE file.
+
+package ynab_test
+
+// The schema half of the spec contract. G1 diffs operation tuples and the
+// content pin proves the spec file is the one that was reviewed, but
+// neither notices that a wire constant transcribed into Go has stopped
+// matching the schema it came from. SPEC's standing rule is that wire
+// constraints come from openapi.yaml and never from memory; these tests
+// are what make that enforceable rather than aspirational.
+//
+// Both directions are asserted. A value that drifts fails on comparison; a
+// bound or enum that upstream ADDS fails on completeness, because an
+// unmapped one is the case a value check can never see.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"pkg.venceslau.dev/ynab"
+	"pkg.venceslau.dev/ynab/internal/contract"
+)
+
+// wireBounds maps every maxLength the spec declares — including the ones a
+// schema inherits through allOf, which is the set the wire enforces — to the
+// Go constant that enforces it. Several schemas share a constant: the
+// transaction, subtransaction and scheduled-transaction payloads bound
+// payee_name and memo identically, and ScheduledTransactionSpec.validate
+// reuses the transaction constants rather than declaring its own.
+var wireBounds = map[[2]string]int{
+	{"NewTransaction", "import_id"}:                     ynab.ImportIDMax,
+	{"NewTransaction", "payee_name"}:                    ynab.TransactionPayeeNameMax,
+	{"NewTransaction", "memo"}:                          ynab.MemoMax,
+	{"ExistingTransaction", "payee_name"}:               ynab.TransactionPayeeNameMax,
+	{"ExistingTransaction", "memo"}:                     ynab.MemoMax,
+	{"SaveTransactionWithOptionalFields", "payee_name"}: ynab.TransactionPayeeNameMax,
+	{"SaveTransactionWithOptionalFields", "memo"}:       ynab.MemoMax,
+	{"SaveTransactionWithIdOrImportId", "payee_name"}:   ynab.TransactionPayeeNameMax,
+	{"SaveTransactionWithIdOrImportId", "memo"}:         ynab.MemoMax,
+	{"SaveSubTransaction", "payee_name"}:                ynab.TransactionPayeeNameMax,
+	{"SaveSubTransaction", "memo"}:                      ynab.MemoMax,
+	{"SaveScheduledTransaction", "payee_name"}:          ynab.TransactionPayeeNameMax,
+	{"SaveScheduledTransaction", "memo"}:                ynab.MemoMax,
+	{"PostPayee", "name"}:                               ynab.PayeeNameMax,
+	{"SavePayee", "name"}:                               ynab.PayeeNameMax,
+	{"SaveCategoryGroup", "name"}:                       ynab.CategoryGroupNameMax,
+}
+
+// wireBoundsUnenforced records the bounds this library does NOT pre-flight,
+// with the reason. A bound belongs here rather than in wireBounds only when
+// leaving it unchecked is a decision someone made; the completeness
+// assertion accepts either table, so the spec can never declare a bound
+// that goes entirely unremarked.
+var wireBoundsUnenforced = map[[2]string]string{
+	{"SaveTransactionWithIdOrImportId", "import_id"}: "PatchByImportID's key reaches the wire " +
+		"unchecked: TransactionPatch embeds TransactionUpdate, which has no ImportID field, so " +
+		"UpdateBatch validates everything except this. A >36-character key comes back a server " +
+		"400 instead of an *ArgumentError. Tracked as a follow-up; enforcing it is a behavior " +
+		"change and belongs in its own commit.",
+}
+
+// wireEnums maps every enum the spec declares on a NAMED schema to the Go
+// enum type that mirrors it. The Go members come from the same AST scan
+// TestEnumValidTables uses, so neither side is hand-repeated here.
+//
+// Scope, stated because the set is not everything transcribed: the spec also
+// declares four enums inline on properties inside components: — GoalType,
+// GoalFrequency and HybridType, which would pin cleanly today, and
+// DebtTransactionType, whose Go set has eight members against the spec's
+// four, sourced deliberately from docs/v1/research. Pinning the first three
+// and waiving the fourth is a follow-up, not a claim this file already makes.
+var wireEnums = map[string]string{
+	"AccountType":                   "AccountType",
+	"SaveAccountType":               "AccountSpecType",
+	"TransactionClearedStatus":      "ClearedStatus",
+	"TransactionFlagColor":          "FlagColor",
+	"ScheduledTransactionFrequency": "Frequency",
+}
+
+// wireNullableEnums pins which of those enums admit a bare null. The Go side
+// models that through the type — *FlagColor on reads, Optional[FlagColor] on
+// writes — so a change here is a change to what those types must be.
+var wireNullableEnums = map[string]bool{
+	"AccountType":                   false,
+	"SaveAccountType":               false,
+	"TransactionClearedStatus":      false,
+	"TransactionFlagColor":          true,
+	"ScheduledTransactionFrequency": false,
+}
+
+// TestContractWireBounds diffs the transcribed maxLength constants against
+// the spec, both ways.
+func TestContractWireBounds(t *testing.T) {
+	t.Parallel()
+
+	schemas, err := contract.ScanSchemas("openapi.yaml")
+	require.NoError(t, err)
+	require.Len(t, schemas.Bounds, len(wireBounds)+len(wireBoundsUnenforced),
+		"every bound the spec declares must be mapped or waived, and nothing else")
+
+	for key, want := range wireBounds {
+		got, ok := schemas.BoundFor(key[0], key[1])
+		require.True(t, ok,
+			"spec no longer declares maxLength on %s.%s; the Go bound is now unanchored",
+			key[0], key[1])
+		require.Equal(t, want, got,
+			"%s.%s: the spec says %d, the Go constant says %d — re-vendoring moved the bound "+
+				"and the constant was not updated with it", key[0], key[1], got, want)
+	}
+
+	for _, b := range schemas.Bounds {
+		key := [2]string{b.Schema, b.Property}
+		if _, waived := wireBoundsUnenforced[key]; waived {
+			continue
+		}
+		require.Contains(t, wireBounds, key,
+			"spec declares maxLength %d on %s.%s and nothing in this library enforces it; "+
+				"map it to a constant, or record why not in wireBoundsUnenforced",
+			b.MaxLength, b.Schema, b.Property)
+	}
+
+	for key := range wireBoundsUnenforced {
+		_, ok := schemas.BoundFor(key[0], key[1])
+		require.True(t, ok,
+			"%s.%s is waived as unenforced but the spec no longer declares it — drop the waiver",
+			key[0], key[1])
+	}
+}
+
+// TestContractWireEnums diffs the Go enum member sets against the spec's,
+// both ways, and pins which admit a null.
+func TestContractWireEnums(t *testing.T) {
+	t.Parallel()
+
+	schemas, err := contract.ScanSchemas("openapi.yaml")
+	require.NoError(t, err)
+	require.Len(t, schemas.Enums, len(wireEnums),
+		"every schema-level enum must be mapped, and nothing else")
+
+	goEnums := scanEnumConsts(t)
+
+	for specName, goName := range wireEnums {
+		specValues, ok := schemas.EnumFor(specName)
+		require.True(t, ok, "spec no longer declares an enum on %s", specName)
+
+		goValues, ok := goEnums[goName]
+		require.True(t, ok, "no Go enum named %s; the mapping is stale", goName)
+
+		// ElementsMatch, not Equal: the spec's declaration order is
+		// upstream's business, and reordering is not drift.
+		require.ElementsMatch(t, specValues, goValues,
+			"%s does not match spec enum %s — upstream added or removed a wire value",
+			goName, specName)
+
+		hasNull, ok := schemas.NullableEnum(specName)
+		require.True(t, ok)
+		require.Equal(t, wireNullableEnums[specName], hasNull,
+			"%s changed nullability upstream — the Go type models that as a pointer or "+
+				"Optional, so this is a type change, not a value change", specName)
+	}
+
+	for _, e := range schemas.Enums {
+		require.Contains(t, wireEnums, e.Schema,
+			"spec declares an enum on %s that no Go type mirrors: %q", e.Schema, e.Values)
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -43,3 +43,14 @@ func EncodeTransactionFilter(f TransactionFilter) url.Values {
 func ValidateTransactionSpec(s TransactionSpec) error {
 	return s.validate("Transactions.Create")
 }
+
+// The transcribed wire bounds, exposed so the contract test can diff them
+// against the maxLength values the vendored spec declares. They are the
+// only numbers in this package copied from the spec by hand.
+const (
+	ImportIDMax             = importIDMax
+	TransactionPayeeNameMax = transactionPayeeNameMax
+	MemoMax                 = memoMax
+	PayeeNameMax            = payeeNameMax
+	CategoryGroupNameMax    = categoryGroupNameMax
+)

--- a/internal/contract/schema.go
+++ b/internal/contract/schema.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Bruno Venceslau. All rights reserved.
+// Use of this source code is governed by a BSD-2-Clause
+// license that can be found in the LICENSE file.
+
+package contract
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Bound is one maxLength the spec declares on a schema property, including
+// the ones a schema inherits through allOf.
+type Bound struct {
+	Schema    string
+	Property  string
+	MaxLength int
+}
+
+// Enum is one enum set the spec declares directly on a named schema.
+// HasNull records a bare null member separately: the Go enums model
+// nullability through the type, not through a sentinel value, so the two
+// are compared on their scalar members alone.
+type Enum struct {
+	Schema  string
+	Values  []string
+	HasNull bool
+}
+
+// Schemas is the resolved view of the components: section.
+type Schemas struct {
+	Bounds []Bound
+	Enums  []Enum
+}
+
+// ScanSchemas reads the maxLength bounds and schema-level enum sets out of
+// the vendored spec's components: section — the half ScanSpec is
+// deliberately blind to.
+//
+// Unlike ScanSpec this parses rather than scans lines. ScanSpec can afford a
+// line scanner because the paths: layout it reads is strictly regular and it
+// fails closed on an empty result. Neither holds here: components: mixes
+// six-space properties with allOf branches four columns deeper, and a spec
+// with no bounds is indistinguishable from a scanner that stopped matching.
+// A hand-rolled version of this was written first and measured wrong four
+// ways — a property in flow style vanished silently, a nested properties:
+// dropped its enclosing block's later siblings, an inline object attached
+// its inner property to the outer schema, and a comment inside an enum list
+// truncated the members. kin-openapi is already a direct test dependency, so
+// the parser costs no new module edge and removes all four classes rather
+// than narrowing them.
+//
+// Bounds include those reached through allOf, which is the set the wire
+// actually enforces: NewTransaction declares only import_id itself and
+// inherits payee_name and memo from SaveTransactionWithOptionalFields.
+func ScanSchemas(path string) (*Schemas, error) {
+	doc, err := openapi3.NewLoader().LoadFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("contract: load spec: %w", err)
+	}
+	if doc.Components == nil || len(doc.Components.Schemas) == 0 {
+		return nil, fmt.Errorf("contract: %s declares no component schemas", path)
+	}
+
+	var out Schemas
+	for name, ref := range doc.Components.Schemas {
+		if ref.Value == nil {
+			continue
+		}
+		collectBounds(name, ref.Value, &out, map[*openapi3.Schema]bool{})
+		if e, ok := enumOf(name, ref.Value); ok {
+			out.Enums = append(out.Enums, e)
+		}
+	}
+
+	// Map iteration is unordered; callers compare sets, but a stable order
+	// keeps failure output diffable.
+	sort.Slice(out.Bounds, func(i, j int) bool {
+		if out.Bounds[i].Schema != out.Bounds[j].Schema {
+			return out.Bounds[i].Schema < out.Bounds[j].Schema
+		}
+		return out.Bounds[i].Property < out.Bounds[j].Property
+	})
+	sort.Slice(out.Enums, func(i, j int) bool { return out.Enums[i].Schema < out.Enums[j].Schema })
+	return &out, nil
+}
+
+// collectBounds records every maxLength on s and on the schemas it composes
+// through allOf, attributing each to the named schema that reaches it. The
+// seen set guards against a cyclic allOf.
+func collectBounds(name string, s *openapi3.Schema, out *Schemas, seen map[*openapi3.Schema]bool) {
+	if s == nil || seen[s] {
+		return
+	}
+	seen[s] = true
+
+	for prop, ref := range s.Properties {
+		if ref.Value == nil || ref.Value.MaxLength == nil {
+			continue
+		}
+		// The spec's bounds are small (36..500). Anything past MaxInt is
+		// not a length this library could enforce anyway, and narrowing it
+		// silently would turn an absurd bound into a plausible one.
+		if n := *ref.Value.MaxLength; n <= math.MaxInt {
+			out.Bounds = append(out.Bounds, Bound{name, prop, int(n)})
+		}
+	}
+	for _, branch := range s.AllOf {
+		collectBounds(name, branch.Value, out, seen)
+	}
+}
+
+// enumOf returns the enum declared directly on a named schema, splitting a
+// bare null out of the scalar members. Property-level enums are not
+// collected: the Go types this pins are named wire enums, and the four
+// inline ones under components: are a separate, deliberate scope decision
+// recorded by the caller.
+func enumOf(name string, s *openapi3.Schema) (Enum, bool) {
+	if len(s.Enum) == 0 {
+		return Enum{}, false
+	}
+	e := Enum{Schema: name}
+	for _, v := range s.Enum {
+		if v == nil {
+			e.HasNull = true
+			continue
+		}
+		e.Values = append(e.Values, fmt.Sprint(v))
+	}
+	return e, true
+}
+
+// BoundFor returns the maxLength the spec declares for schema.property.
+func (s *Schemas) BoundFor(schema, property string) (int, bool) {
+	for _, b := range s.Bounds {
+		if b.Schema == schema && b.Property == property {
+			return b.MaxLength, true
+		}
+	}
+	return 0, false
+}
+
+// EnumFor returns the scalar enum members the spec declares on schema.
+func (s *Schemas) EnumFor(schema string) ([]string, bool) {
+	for _, e := range s.Enums {
+		if e.Schema == schema {
+			return e.Values, true
+		}
+	}
+	return nil, false
+}
+
+// NullableEnum reports whether the spec's enum on schema admits a bare null.
+func (s *Schemas) NullableEnum(schema string) (bool, bool) {
+	for _, e := range s.Enums {
+		if e.Schema == schema {
+			return e.HasNull, true
+		}
+	}
+	return false, false
+}

--- a/internal/contract/schema_test.go
+++ b/internal/contract/schema_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Bruno Venceslau. All rights reserved.
+// Use of this source code is governed by a BSD-2-Clause
+// license that can be found in the LICENSE file.
+
+package contract_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"pkg.venceslau.dev/ynab/internal/contract"
+)
+
+// TestContractScanSchemas pins the resolved view against the real vendored
+// spec. The counts are exact: this is the input two gates diff against, and
+// a change in what the spec declares must be seen, not averaged away.
+func TestContractScanSchemas(t *testing.T) {
+	t.Parallel()
+
+	s, err := contract.ScanSchemas(specPath)
+	require.NoError(t, err)
+
+	require.Len(t, s.Bounds, 17, "11 declared inline, 6 more reached through allOf")
+	require.Len(t, s.Enums, 5, "the spec declares 5 schema-level enums")
+
+	// allOf resolution is the reason this parses rather than scans lines:
+	// NewTransaction declares only import_id and inherits the other two.
+	for _, want := range []contract.Bound{
+		{Schema: "NewTransaction", Property: "import_id", MaxLength: 36},
+		{Schema: "NewTransaction", Property: "payee_name", MaxLength: 200},
+		{Schema: "NewTransaction", Property: "memo", MaxLength: 500},
+	} {
+		got, ok := s.BoundFor(want.Schema, want.Property)
+		require.True(t, ok, "%s.%s must resolve through allOf", want.Schema, want.Property)
+		require.Equal(t, want.MaxLength, got)
+	}
+
+	// An ordinary directly-declared property, for contrast.
+	got, ok := s.BoundFor("SaveCategoryGroup", "name")
+	require.True(t, ok)
+	require.Equal(t, 50, got)
+
+	_, ok = s.BoundFor("SaveCategoryGroup", "no_such_property")
+	require.False(t, ok, "a miss reports false, not a zero bound")
+
+	// FlagColor carries both spellings the scanner separates: the empty
+	// string is a member, a bare null is not.
+	values, ok := s.EnumFor("TransactionFlagColor")
+	require.True(t, ok)
+	require.ElementsMatch(t,
+		[]string{"red", "orange", "yellow", "green", "blue", "purple", ""}, values)
+
+	hasNull, ok := s.NullableEnum("TransactionFlagColor")
+	require.True(t, ok)
+	require.True(t, hasNull, "a bare null member is recorded apart from the scalars")
+
+	hasNull, ok = s.NullableEnum("TransactionClearedStatus")
+	require.True(t, ok)
+	require.False(t, hasNull)
+
+	_, ok = s.EnumFor("NoSuchSchema")
+	require.False(t, ok)
+}
+
+// TestContractScanSchemasShapes drives the parser over hand-written
+// documents. These are the shapes a hand-rolled line scanner got wrong —
+// flow style, a nested properties: block, an inline object, an allOf chain —
+// kept as regression cases so a future change back to scanning cannot pass
+// quietly. Written as fixtures rather than mutations of the vendored spec so
+// a re-vendor cannot change what they prove.
+func TestContractScanSchemasShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		doc        string
+		wantBounds []contract.Bound
+		wantEnums  int
+	}{{
+		name: "block style",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    SavePayee:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 500
+`,
+		wantBounds: []contract.Bound{{Schema: "SavePayee", Property: "name", MaxLength: 500}},
+	}, {
+		name: "flow style — invisible to a line scanner",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    SavePayee:
+      type: object
+      properties: {name: {type: string, maxLength: 500}}
+`,
+		wantBounds: []contract.Bound{{Schema: "SavePayee", Property: "name", MaxLength: 500}},
+	}, {
+		name: "a sibling after a nested object is not dropped",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        nested:
+          type: object
+          properties:
+            inner:
+              type: string
+              maxLength: 5
+        name:
+          type: string
+          maxLength: 10
+`,
+		// inner belongs to Thing.nested, not to Thing: only the top-level
+		// property is a bound on Thing.
+		wantBounds: []contract.Bound{{Schema: "Thing", Property: "name", MaxLength: 10}},
+	}, {
+		name: "an array item's property is not attributed to the outer schema",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        legs:
+          type: array
+          items:
+            type: object
+            properties:
+              memo:
+                type: string
+                maxLength: 500
+`,
+	}, {
+		name: "allOf contributes the branch's bounds to the composing schema",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Base:
+      type: object
+      properties:
+        memo:
+          type: string
+          maxLength: 500
+    Derived:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+        - type: object
+          properties:
+            import_id:
+              type: string
+              maxLength: 36
+`,
+		wantBounds: []contract.Bound{
+			{Schema: "Base", Property: "memo", MaxLength: 500},
+			{Schema: "Derived", Property: "import_id", MaxLength: 36},
+			{Schema: "Derived", Property: "memo", MaxLength: 500},
+		},
+	}, {
+		name: "a property-level enum is not a schema-level one",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Colors:
+      type: string
+      enum: [red, ""]
+    Thing:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [inline]
+`,
+		wantEnums: 1,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "spec.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(tc.doc), 0o600))
+
+			s, err := contract.ScanSchemas(path)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantBounds, s.Bounds)
+			require.Len(t, s.Enums, tc.wantEnums)
+		})
+	}
+}
+
+// TestContractScanSchemasErrors covers the failure paths.
+func TestContractScanSchemasErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := contract.ScanSchemas(filepath.Join(t.TempDir(), "absent.yaml"))
+	require.Error(t, err, "a missing spec must fail loudly")
+
+	path := filepath.Join(t.TempDir(), "broken.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("this: is: not: a spec\n"), 0o600))
+	_, err = contract.ScanSchemas(path)
+	require.Error(t, err, "an unparseable document must fail loudly")
+
+	path = filepath.Join(t.TempDir(), "empty.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+`), 0o600))
+	_, err = contract.ScanSchemas(path)
+	require.ErrorContains(t, err, "no component schemas",
+		"a spec with no schemas must fail closed, not report an empty set")
+}


### PR DESCRIPTION
Task 52. The structured half of gap 2 from #49 — the content pin (#51) closed detection, this closes attribution.

## The problem

SPEC's standing rule is that wire constraints come from `openapi.yaml`, never from memory. Five `maxLength` constants and five string-enum sets were copied out by hand, and nothing checked they still matched.

**The content pin does not cover this.** It notices the spec file moved — necessary, not sufficient. A maintainer reviews the diff, re-pins the digest, and a bound upstream tightened stays stale in Go. The client then rejects payloads the server accepts, pre-flight, with no request sent: a false `*ArgumentError` no gate would attribute to the spec.

## Why a parser, not a scanner

I wrote a hand-rolled line scanner first. Review measured it wrong **four** ways:

| shape | failure |
|---|---|
| property in flow style | vanished silently |
| nested `properties:` | dropped the enclosing block's later siblings |
| inline object | attached its inner property to the outer schema |
| `#` comment inside an enum list | truncated the members |

Two are **false positives** — a bound pinned to the wrong schema is worse than a missing one, because the completeness direction can only iterate what the scanner found. `kin-openapi` is already a direct test dependency, so the parser costs no new module edge and removes all four classes instead of narrowing them.

Parsing also reaches what the scanner structurally could not: **bounds inherited through `allOf`** — the set the wire actually enforces. `NewTransaction` declares only `import_id` and inherits `payee_name` and `memo`. The gate covers **17** bounds, not the 11 written inline.

## Both directions

A drifted value fails on comparison; a bound or enum upstream *adds* fails on completeness — the case a value check can never see, and what makes this more than a restatement of the digest.

## One bound is not enforced, and says so

16 of 17 map onto the 5 constants. `SaveTransactionWithIdOrImportId.import_id` does **not**: `TransactionPatch` embeds `TransactionUpdate`, which has no `ImportID` field, so `UpdateBatch` validates everything except this — a >36-character `PatchByImportID` key reaches the wire and returns a server 400. Rather than claim otherwise, `wireBoundsUnenforced` records it with the reason. The completeness assertion accepts either table, so the spec can never declare a bound that goes entirely unremarked. Enforcing it is a behavior change and belongs in its own commit.

## Mutation-tested

A bound tightened, loosened, or moved inside an `allOf`; an enum member added or removed; the `null` dropped from `FlagColor`; a Go constant edited; and a flow-style bound the line scanner missed entirely — all bite. A `components.parameters` section, which the line scanner reported as a schema-level enum, is now correctly ignored.

## Gates

`make local-ci` exit 0. Coverage 97.1% → **97.0%** — the parser's error and boundary branches are not all reachable from the vendored spec, and the layout fixtures the scanner needed are gone. Test-only and `internal/`; no public surface moved.

## Review disclosure

Fan-out on **Opus 5, not Fable** (Fable exhausted; substitution signed off). Reviewers found, in my prose: a justification naming a set the guard did not touch, a fabricated coverage baseline, and a "nothing unenforced" claim the code disproves. All three are corrected here; the third became the waiver table.