### PR TITLE
ci: retry the drift fetch, and split blips from refusals

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,10 @@ jobs:
         if: matrix.go != '1.25.x'
         run: make check-version-selftest
 
+      - name: make spec-shape-selftest
+        if: matrix.go != '1.25.x'
+        run: make spec-shape-selftest
+
       - name: make coverage
         if: matrix.go != '1.25.x'
         run: make coverage

--- a/.github/workflows/drift.yaml
+++ b/.github/workflows/drift.yaml
@@ -3,6 +3,9 @@
 # the diff as an artifact. Red-only — re-vendoring is a deliberate human
 # change, never automated (and this repository opens no automatic PRs).
 #
+# Red means drift and nothing else. A failed fetch warns and leaves the run
+# green: see the fetch step for why that trade is the right way round.
+#
 # This workflow watches the spec and nothing else. Its toolchain twin lives
 # in go-drift.yaml: a status badge reports the RUN conclusion, so while
 # the two shared a file a stale Go pin turned the spec-drift badge red with
@@ -27,12 +30,54 @@ jobs:
         with:
           persist-credentials: false
 
+      # Same flags as the update-spec recipe, plus retries and an exit-code
+      # split. This job's conclusion is a public badge, and the only thing it
+      # is entitled to assert is "the vendored spec drifted". A DNS blip at
+      # 06:17 on a Monday is not that, and would otherwise paint the README
+      # red for a week — the trigger is weekly, so nothing re-runs it — while
+      # openapi.yaml is byte-identical to live.
+      #
+      # But warn-and-green cannot be the answer for EVERY failure. Under -f a
+      # moved spec URL is a 404, and swallowing that would leave the badge
+      # green while nothing was compared for months: a false red gets
+      # investigated, a false green does not. So the two are separated by
+      # curl's exit code — connection-class failures warn, an endpoint that
+      # answered and refused stays red.
+      #
+      # --retry-all-errors is what makes the retries reach the case this is
+      # about. Bare --retry covers only transient HTTP classes (408, 429,
+      # 5xx) and does NOT retry a refused connection at all — measured, exit
+      # 7 comes back in 0.0s without the flag and after 15.0s with it.
       - name: fetch live spec    # local equivalent: the update-spec curl, into a temp file
+        id: fetch
         run: |
+          rc=0
           curl --proto '=https' --tlsv1.2 --max-time 60 -fsS --remove-on-error \
-            https://api.ynab.com/papi/open_api_spec.yaml -o /tmp/live_spec.yaml
+            --retry 3 --retry-all-errors --retry-delay 5 \
+            https://api.ynab.com/papi/open_api_spec.yaml -o /tmp/live_spec.yaml || rc=$?
+          case $rc in
+            0)
+              echo 'fetched=true' >> "$GITHUB_OUTPUT"
+              ;;
+            6|7|28|35|52|56)
+              # DNS, connect, timeout, TLS, empty reply, reset — the network
+              # was in the way and the endpoint never answered.
+              echo 'fetched=false' >> "$GITHUB_OUTPUT"
+              echo "::warning::could not reach api.ynab.com after retries (curl exit $rc) — spec drift NOT checked this run. This is a fetch failure, not drift."
+              ;;
+            *)
+              # 22 is -f on an HTTP status >= 400: the endpoint answered and
+              # refused. A moved or renamed spec URL lands here, and it is the
+              # most likely long-term failure of a third-party endpoint —
+              # permanent, not a blip, and silence would leave the badge green
+              # while nothing was compared for months.
+              echo "::error::spec fetch failed definitively (curl exit $rc) — the endpoint answered and refused. This is not a network blip; check whether the spec URL moved."
+              exit 1
+              ;;
+          esac
 
       - name: diff against vendored
+        if: steps.fetch.outputs.fetched == 'true'
         run: |
           if ! diff -u openapi.yaml /tmp/live_spec.yaml > /tmp/spec.diff; then
             echo '::error::live OpenAPI spec drifted from the vendored 1.86.0 pin — download the spec-diff artifact and re-vendor deliberately'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 # The vendored OpenAPI spec is a tracked repo artifact — the contract-test
 # source of truth. A host-level ignore matches it, so re-include it here.
 !/openapi.yaml
+
+# update-spec stages the download beside the artifact so the move is atomic
+# and same-filesystem, and keeps the file when the shape check refuses it so
+# the maintainer can look at what arrived. Neither is ever committed.
+/openapi.yaml.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,22 @@ All notable changes to this module are documented here, in
   which is the case a value check can never see. Mutation-tested: a
   `maxLength` moved, an enum value added, one removed, a new unmapped bound,
   and either Go side edited — six for six. Test-only; no public surface.
+- `make update-spec` now fetches to a temp file and only replaces the vendored
+  spec once `scripts/spec-shape.sh` agrees the download carries the same
+  operation count as the file it would overwrite. A shape check, not a
+  validity one — the content pin is what covers the bytes. This closes the gap the
+  fetch flags cannot reach: a redirect is not an error under `-f`, so
+  `--remove-on-error` never fires on one, and curl wrote the 302's own body —
+  attacker-chosen, not merely empty — at exit 0, destroying the vendored
+  artifact while the recipe reported success. Three controls now, none
+  subsuming another: curl's non-zero exit covers a truncated transfer, which
+  keeps the operation count and so is invisible to the shape check; the shape
+  check covers a body whose count differs; the content pin covers the bytes. A network-free
+  self-test of 17 fixtures, wired into `local-ci` and CI, pins the parts a
+  coarse suite would miss — a near-miss pair fixing *how* the count is
+  computed, distinct exit codes for "not a spec" and "called wrong", a
+  missing or operationless baseline, and a refusal to answer at all when the
+  input cannot be scanned. Tooling only; no module byte changes.
 
 ## [1.6.1] - 2026-07-21
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ ACTIONLINT := CGO_ENABLED=0 go run github.com/rhysd/actionlint/cmd/actionlint@$(
 GORELEASE_CMD := go run golang.org/x/exp/cmd/gorelease@$(XEXP_VERSION)
 
 .PHONY: test vet lint contract coverage update-spec smoke integration vulncheck tidy-check actionlint \
-	check-version-selftest local-ci go-latest-check apidiff apidiff-selftest examples
+	check-version-selftest local-ci go-latest-check apidiff apidiff-selftest examples \
+	spec-shape-selftest
 
 test:
 	go test -race -shuffle=on ./...
@@ -51,16 +52,37 @@ vulncheck:
 #
 # The fetch flags are supply-chain controls on an artifact that ships inside
 # the module zip. --proto '=https' pins the scheme, --tlsv1.2 sets a floor,
-# -f keeps a 4xx/5xx error page off disk, and --max-time mirrors drift.yaml.
-# No -L: the endpoint answers 200 directly, and following a redirect would
-# let whatever host a Location names supply the bytes. --remove-on-error
-# deletes a partial download — every operation and the version line precede
-# components:, so a body cut there still scans as 44 valid ops and passes
-# every offline gate.
+# -f keeps a 4xx/5xx error page off disk, --max-time mirrors drift.yaml, and
+# --remove-on-error is belt-and-braces now that a rejected download never
+# becomes the artifact anyway. No -L: the endpoint answers 200 directly, and
+# following a redirect would let whatever host a Location names supply the
+# bytes. What actually covers a truncated transfer is curl's non-zero exit,
+# which aborts the recipe before the move.
+#
+# The download is staged beside the artifact — same filesystem, so the move
+# is a rename — and replaces it only once scripts/spec-shape.sh agrees the
+# operation count matches. That header explains what the check does and does
+# not buy; it is not repeated here. On refusal the staged file is left in
+# place, deliberately, so the maintainer can read what arrived.
+#
+# chmod because mktemp creates 0600 and the tracked artifact is 0644.
 update-spec:
+	@set -e; tmp=$$(mktemp ./openapi.yaml.XXXXXX); \
+	trap 'rm -f "$$tmp"' EXIT; \
 	curl --proto '=https' --tlsv1.2 --max-time 60 -fsS --remove-on-error \
-		https://api.ynab.com/papi/open_api_spec.yaml -o openapi.yaml
+		https://api.ynab.com/papi/open_api_spec.yaml -o "$$tmp"; \
+	if ! scripts/spec-shape.sh openapi.yaml "$$tmp"; then \
+		trap - EXIT; exit 1; \
+	fi; \
+	mv "$$tmp" openapi.yaml; \
+	chmod 0644 openapi.yaml
 	git diff --stat openapi.yaml
+
+# The network-free proof that spec-shape.sh accepts the spec and refuses
+# every other document update-spec can plausibly download. Twin of
+# check-version-selftest and apidiff-selftest; no curl, fixtures only.
+spec-shape-selftest:
+	@scripts/spec-shape-selftest.sh
 
 # -count=1: live-API runs must never be served from the test cache.
 # CGO_ENABLED=0: no -race here, so cgo buys nothing and blocks nothing.
@@ -111,7 +133,8 @@ apidiff-selftest:
 	@scripts/apidiff-selftest.sh
 
 # Everything the CI's full leg runs, locally — burn zero Actions minutes.
-local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest apidiff apidiff-selftest coverage
+local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest \
+	apidiff apidiff-selftest spec-shape-selftest coverage
 
 # The check behind .github/workflows/go-drift.yaml, which runs it weekly:
 # fails when go.dev lists a newer stable Go than the newest one pinned in

--- a/scripts/spec-shape-selftest.sh
+++ b/scripts/spec-shape-selftest.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bruno Venceslau. All rights reserved.
+# Use of this source code is governed by a BSD-2-Clause
+# license that can be found in the LICENSE file.
+#
+# The network-free proof that spec-shape.sh accepts the spec and refuses
+# everything else `make update-spec` can plausibly download. Twin of
+# apidiff-selftest and check-version-selftest: no curl, no live endpoint.
+#
+# The baseline is the real vendored spec, deliberately: the "unchanged spec
+# is accepted" case wants the real artifact, and no `44` literal appears
+# anywhere here, so a legitimate re-vendor causes zero churn. The cost is
+# that fixtures DERIVED from it can silently degenerate when upstream moves
+# the lines they edit — so each one asserts it actually differs as intended
+# before it is used. A fixture that stopped discriminating would otherwise
+# leave the suite green while proving nothing.
+set -euo pipefail
+
+here=$(cd "$(dirname "$0")" && pwd)
+shape="$here/spec-shape.sh"
+vendored="$here/../openapi.yaml"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+
+note() { echo "FAIL: $1"; fail=1; }
+
+# ok <name> <candidate> — the check must accept.
+ok() {
+	if "$shape" "$vendored" "$2" >/dev/null 2>&1; then
+		echo "ok: $1"
+	else
+		note "$1 — the check rejected a document it should accept"
+	fi
+}
+
+# rejects <name> <candidate> <expected-exit> — the check must refuse, with
+# that exact code. 1 means "not a spec"; 2 means "you called me wrong".
+rejects() {
+	local rc=0
+	"$shape" "$vendored" "$2" >/dev/null 2>&1 || rc=$?
+	if [ "$rc" -eq "$3" ]; then
+		echo "ok (fail): $1"
+	else
+		note "$1 — expected exit $3, got $rc"
+	fi
+}
+
+# Same fail-closed discipline spec-shape.sh's count() documents: a bare
+# `|| true` would turn an unscannable fixture into a silent zero.
+anchored() {
+	local n rc=0
+	n=$(grep -c '^      operationId:' -- "$1") || rc=$?
+	if [ "$rc" -gt 1 ]; then
+		note "cannot scan fixture $1 (grep exited $rc)"
+		printf '%s\n' -1
+		return
+	fi
+	printf '%s\n' "${n:-0}"
+}
+want=$(anchored "$vendored")
+
+cp "$vendored" "$tmp/same.yaml"
+ok "the live spec unchanged is vendored" "$tmp/same.yaml"
+
+# A description-only upstream edit must still be vendorable: this gate
+# guards the operation set, not the bytes. The content pin guards those.
+sed 's/^      description: .*/      description: reworded upstream/' "$vendored" > "$tmp/reworded.yaml"
+if cmp -s "$vendored" "$tmp/reworded.yaml"; then
+	note "the reworded fixture is byte-identical to the baseline — the sed stopped matching"
+elif [ "$(anchored "$tmp/reworded.yaml")" -ne "$want" ]; then
+	note "the reworded fixture changed the operation count — it no longer isolates description edits"
+else
+	ok "a description-only upstream edit is vendored" "$tmp/reworded.yaml"
+fi
+
+printf '<html><head><title>302 Found</title></head><body>Moved</body></html>\n' > "$tmp/redirect.html"
+rejects "a redirect body does not become the spec" "$tmp/redirect.html" 1
+
+: > "$tmp/empty.yaml"
+rejects "an empty body does not become the spec" "$tmp/empty.yaml" 1
+
+printf 'error: not found\n' > "$tmp/error.txt"
+rejects "an error page does not become the spec" "$tmp/error.txt" 1
+
+awk '!d && /^      operationId:/ { print "      operationId: extraThing"; d = 1 } { print }' \
+	"$vendored" > "$tmp/extra.yaml"
+if [ "$(anchored "$tmp/extra.yaml")" -ne $((want + 1)) ]; then
+	note "the added-operation fixture did not add one — it proves nothing"
+else
+	rejects "an added operation is not a silent refresh" "$tmp/extra.yaml" 1
+fi
+
+awk '!d && /^      operationId:/ { d = 1; next } { print }' \
+	"$vendored" > "$tmp/missing.yaml"
+if [ "$(anchored "$tmp/missing.yaml")" -ne $((want - 1)) ]; then
+	note "the removed-operation fixture did not remove one — it proves nothing"
+else
+	rejects "a removed operation is not a silent refresh" "$tmp/missing.yaml" 1
+fi
+
+# The near-miss pair. Both cases score the same under an unanchored match
+# and differently under the real one, so together they pin HOW the count is
+# computed — not just that some count is compared. Upstream writes
+# `operationId` into prose routinely, so an unanchored pattern is reachable.
+awk '!d && /^      operationId:/ { print "      # operationId is mentioned here in prose"; d = 1; next } { print }' \
+	"$vendored" > "$tmp/prose-short.yaml"
+if [ "$(anchored "$tmp/prose-short.yaml")" -ne $((want - 1)) ]; then
+	note "the prose near-miss fixture did not trade an operation for a mention"
+else
+	rejects "an operation traded for a prose mention is refused" "$tmp/prose-short.yaml" 1
+fi
+
+{
+	printf '# operationId appears in a comment\n'
+	printf 'x-note: operationId appears in a value\n'
+	cat "$vendored"
+} > "$tmp/prose-extra.yaml"
+if [ "$(anchored "$tmp/prose-extra.yaml")" -ne "$want" ]; then
+	note "the prose-padding fixture changed the anchored count — it proves nothing"
+else
+	ok "prose mentions do not pad the count" "$tmp/prose-extra.yaml"
+fi
+
+# A truncated body is ACCEPTED, and that is the documented division of
+# labour: every operationId precedes components:, so a cut past them keeps
+# the count. What covers a truncated transfer is curl's non-zero exit, which
+# aborts the recipe before the move. Pinned as a characterization case so the
+# claim cannot invert silently if upstream ever reorders the document.
+head -c $(( $(wc -c < "$vendored") / 2 )) "$vendored" > "$tmp/truncated.yaml"
+if [ "$(anchored "$tmp/truncated.yaml")" -ne "$want" ]; then
+	note "a half-truncated spec no longer keeps the operation count — the Makefile comment and spec-shape.sh's header both claim it does, and they are now wrong"
+else
+	ok "a truncated body is accepted — curl's exit is what covers it" "$tmp/truncated.yaml"
+fi
+
+# Fail closed on its own inputs, so a broken call site cannot pass quietly.
+rejects "a missing candidate fails closed" "$tmp/absent.yaml" 2
+
+rc=0
+"$shape" "$tmp/absent-baseline.yaml" "$tmp/same.yaml" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then
+	echo "ok (fail): a missing baseline fails closed"
+else
+	note "a missing baseline must exit 2, got $rc — this is the recovery path after a hijacked fetch already destroyed the vendored spec"
+fi
+
+: > "$tmp/nospec.yaml"
+rc=0
+"$shape" "$tmp/nospec.yaml" "$tmp/same.yaml" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then
+	echo "ok (fail): an operationless baseline is refused, not used"
+else
+	note "an operationless baseline must exit 2, got $rc — otherwise every candidate matches it"
+fi
+
+# A wrong call must not be mistaken for a verdict.
+for argc in 0 1 3; do
+	rc=0
+	case $argc in
+	0) "$shape" >/dev/null 2>&1 || rc=$? ;;
+	1) "$shape" "$vendored" >/dev/null 2>&1 || rc=$? ;;
+	3) "$shape" "$vendored" "$vendored" extra >/dev/null 2>&1 || rc=$? ;;
+	esac
+	if [ "$rc" -eq 2 ]; then
+		echo "ok (fail): a ${argc}-argument call fails closed"
+	else
+		note "a ${argc}-argument call must exit 2, got $rc"
+	fi
+done
+
+# The gate must refuse to answer when it cannot scan. A `grep -c ... || true`
+# would collapse an unscannable input into the empty string, and since POSIX
+# exempts an `if` condition from set -e the comparisons would then error, be
+# read as false, and the script would fall off the end accepting everything.
+minbin=$tmp/bin
+mkdir -p "$minbin"
+for c in sh bash cat printf; do
+	if src=$(command -v "$c" 2>/dev/null); then ln -sf "$src" "$minbin/$c"; fi
+done
+rc=0
+PATH="$minbin" "$shape" "$vendored" "$tmp/redirect.html" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -ne 0 ]; then
+	echo "ok (fail): an unscannable input is refused, not accepted (exit $rc)"
+else
+	note "the gate accepted a redirect body when grep was unavailable — it fails OPEN"
+fi
+
+if [ "$fail" -ne 0 ]; then
+	echo "spec-shape gate self-test FAILED"
+	exit 1
+fi
+echo "ok: spec-shape gate classifies every case correctly"

--- a/scripts/spec-shape.sh
+++ b/scripts/spec-shape.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bruno Venceslau. All rights reserved.
+# Use of this source code is governed by a BSD-2-Clause
+# license that can be found in the LICENSE file.
+#
+# spec-shape.sh <vendored> <candidate>
+#
+# Exits 0 when <candidate> carries the same number of operations as
+# <vendored>. Used by `make update-spec` between the fetch and the move, so a
+# document that is not the spec never becomes the tracked artifact.
+#
+# This is a SHAPE check, not a validity check. A file containing nothing but
+# the right number of `      operationId:` lines passes, as does the genuine
+# spec with a hostile servers: url. What it buys is the one case the fetch
+# flags cannot reach: a redirect is not an error under curl's -f, so the
+# transfer "succeeds" and curl writes the 302's own body — attacker-chosen,
+# not merely empty. Three controls, none subsuming another: curl's non-zero
+# exit covers a truncated transfer, this covers a body whose operation count
+# differs, and contract.SpecSHA256 is the only one that covers the bytes.
+#
+# The expected count comes from <vendored> rather than a literal, so THIS
+# gate needs no edit when the operation set legitimately changes. (44 is
+# still written out in the contract table and its tests — those are the
+# edits such a change is supposed to force.)
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: spec-shape.sh <vendored> <candidate>" >&2
+	exit 2
+fi
+
+vendored=$1
+candidate=$2
+
+for f in "$vendored" "$candidate"; do
+	if [ ! -f "$f" ]; then
+		echo "error: $f does not exist" >&2
+		exit 2
+	fi
+	if [ ! -r "$f" ]; then
+		echo "error: $f is not readable" >&2
+		exit 2
+	fi
+done
+
+# grep exits 1 on zero matches, which is a legitimate answer, and 2+ when it
+# could not scan at all. A bare `|| true` would collapse both into the empty
+# string — and since POSIX exempts an `if` condition from set -e, the two
+# `[ "$x" -eq ... ]` tests below would then error, be read as false, and the
+# script would fall off the end at exit 0. A supply-chain gate that accepts
+# on internal error is worse than no gate, so anything but 0 or 1 is fatal.
+count() {
+	local n rc=0
+	n=$(grep -c '^      operationId:' -- "$1") || rc=$?
+	if [ "$rc" -gt 1 ]; then
+		echo "error: cannot scan $1 (grep exited $rc)" >&2
+		exit 2
+	fi
+	printf '%s\n' "${n:-0}"
+}
+
+want=$(count "$vendored")
+got=$(count "$candidate")
+
+if [ "$want" -eq 0 ]; then
+	echo "error: the vendored spec $vendored declares no operations — refusing to" >&2
+	echo "       compare against it, since every candidate would then pass" >&2
+	exit 2
+fi
+
+if [ "$got" -ne "$want" ]; then
+	echo "error: $candidate declares $got operations, $vendored declares $want — not vendoring." >&2
+	echo "       A redirect body or a wrong document lands here; the candidate is left in" >&2
+	echo "       place above so you can look at what actually arrived." >&2
+	echo "       If upstream really changed the operation set, that is a contract-table" >&2
+	echo "       change: re-fetch with the curl in the update-spec recipe, then update" >&2
+	echo "       internal/contract/table.go and contract.SpecSHA256 in the same commit." >&2
+	exit 1
+fi


### PR DESCRIPTION
Task 50. **Stacked on #56** — targets `main` per the stacking rule, so the diff shows #56's commit until it lands. Review only `d1eee26`.

## The problem

`spec-drift`'s conclusion is a public badge on the README and pkg.go.dev, and the only thing it is entitled to assert is *"the vendored spec drifted"*. An unreachable `api.ynab.com` made it assert that anyway: `curl -f` exits non-zero on a DNS blip, the step failed, the run concluded failure, and the badge went red with `openapi.yaml` byte-identical to live. The trigger is schedule-only, so nothing re-runs it — the false claim stands for a week.

## And why warn-and-green alone is the wrong fix

The first draft of this swallowed *every* failure. Review caught it: under `-f` a **moved spec URL is a 404**, and swallowing that leaves the badge green while nothing is compared for months. A false red gets investigated; a false green does not.

So the two are separated by curl's exit code:

| exit | meaning | outcome |
|---|---|---|
| 0 | fetched | diff runs |
| 6, 7, 28, 35, 52, 56 | DNS, connect, timeout, TLS, empty reply, reset — the network was in the way | `::warning::`, stay **green** |
| anything else (22 above all) | the endpoint answered and refused | `::error::`, stay **red** |

## `--retry-all-errors`, for the opposite reason I first wrote

My first draft justified the flag with "a 429 or a 502 from an origin under load". Both are **already transient classes** that bare `--retry` covers — measured, a local 429 server saw four requests under `--retry 3` alone.

What bare `--retry` does *not* retry is a refused connection. Measured against a dead port:

- without `--retry-all-errors`: exit 7 in **0.0s** — not retried at all
- with it: exit 7 after **15.0s**

Connection and DNS failure is the blip this exists to absorb, and only the flag reaches it.

Worst case, stated accurately: `--max-time` is per attempt, so a blackholed host costs 4×60s + 3×5s ≈ **255s**, inside the job's `timeout-minutes: 10`.

## Gates

Verified against the live endpoint (200, 135272 bytes, byte-identical to the vendored spec) and a dead one; the step's own branches exercised both ways. `make local-ci` exit 0, actionlint clean. The fetch flags themselves are unchanged and still mirror the `update-spec` recipe.

No CHANGELOG line — CONTRIBUTING scopes that to user-visible changes, and this alters when a CI job reports failure, not any module byte.

## Review disclosure

Fan-out on **Opus 5, not Fable**. Both reviewers independently found that warn-and-green swallowed permanent failures, and one measured the `--retry-all-errors` rationale backwards from curl's own documentation. Both corrections are in this commit.