### PR TITLE
ci: pin the spec-fetch flags, and the content pin's human boundary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,14 @@ jobs:
         if: matrix.go != '1.25.x'
         run: make spec-shape-selftest
 
+      - name: make fetch-flags
+        if: matrix.go != '1.25.x'
+        run: make fetch-flags
+
+      - name: make fetch-flags-selftest
+        if: matrix.go != '1.25.x'
+        run: make fetch-flags-selftest
+
       - name: make coverage
         if: matrix.go != '1.25.x'
         run: make coverage

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GORELEASE_CMD := go run golang.org/x/exp/cmd/gorelease@$(XEXP_VERSION)
 
 .PHONY: test vet lint contract coverage update-spec smoke integration vulncheck tidy-check actionlint \
 	check-version-selftest local-ci go-latest-check apidiff apidiff-selftest examples \
-	spec-shape-selftest
+	spec-shape-selftest fetch-flags fetch-flags-selftest
 
 test:
 	go test -race -shuffle=on ./...
@@ -78,6 +78,18 @@ update-spec:
 	chmod 0644 openapi.yaml
 	git diff --stat openapi.yaml
 
+# The spec-fetch flags were reasoned about at length and enforced by
+# nothing: a future edit could restore -L or drop --remove-on-error with
+# every gate green. This turns those comments into a check, and pins that
+# update-spec never computes the content digest itself.
+fetch-flags:
+	@scripts/fetch-flags.sh Makefile .github/workflows/drift.yaml
+
+# The network-free proof that fetch-flags.sh is not vacuous: every flag it
+# claims to require, removed in turn, must be caught.
+fetch-flags-selftest:
+	@scripts/fetch-flags-selftest.sh
+
 # The network-free proof that spec-shape.sh accepts the spec and refuses
 # every other document update-spec can plausibly download. Twin of
 # check-version-selftest and apidiff-selftest; no curl, fixtures only.
@@ -134,7 +146,8 @@ apidiff-selftest:
 
 # Everything the CI's full leg runs, locally — burn zero Actions minutes.
 local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest \
-	apidiff apidiff-selftest spec-shape-selftest coverage
+	apidiff apidiff-selftest spec-shape-selftest \
+	fetch-flags fetch-flags-selftest coverage
 
 # The check behind .github/workflows/go-drift.yaml, which runs it weekly:
 # fails when go.dev lists a newer stable Go than the newest one pinned in

--- a/scripts/fetch-flags-selftest.sh
+++ b/scripts/fetch-flags-selftest.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bruno Venceslau. All rights reserved.
+# Use of this source code is governed by a BSD-2-Clause
+# license that can be found in the LICENSE file.
+#
+# The network-free proof that fetch-flags.sh is not vacuous. Twin of
+# apidiff-selftest, check-version-selftest and spec-shape-selftest.
+#
+# A grep gate's characteristic failure is passing on everything: one wrong
+# pattern and it asserts nothing while reporting ok. So every flag it claims
+# to require is removed in turn and must be caught, and the -L it must NOT
+# police elsewhere is exercised too.
+#
+# Fixtures are hand-written rather than derived from the real Makefile: the
+# gate's whole job is to notice the real files changing, so deriving the
+# fixtures from them would couple the proof to the thing under test.
+set -euo pipefail
+
+here=$(cd "$(dirname "$0")" && pwd)
+gate="$here/fetch-flags.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+note() { echo "FAIL: $1"; fail=1; }
+
+url=https://api.ynab.com/papi/open_api_spec.yaml
+flags="--proto '=https' --tlsv1.2 --max-time 60 -fsS --remove-on-error"
+
+# mkmake <path> <curl-flags> [extra-recipe-line]
+mkmake() {
+	{
+		printf 'update-spec:\n'
+		printf '\tcurl %s \\\n' "$2"
+		printf '\t\t%s -o openapi.yaml\n' "$url"
+		[ "$#" -ge 3 ] && printf '\t%s\n' "$3"
+		printf '\tgit diff --stat openapi.yaml\n'
+		printf '\n'
+		printf 'go-latest-check:\n'
+		# A legitimate -L elsewhere: parses a string, vendors nothing.
+		printf "\t@curl --proto '=https' --tlsv1.2 -fsSL 'https://go.dev/dl/?mode=json'\n"
+	} > "$1"
+}
+
+mkflow() {
+	{
+		printf 'name: spec-drift\n'
+		printf 'jobs:\n  diff:\n    steps:\n      - run: |\n'
+		printf '          curl %s \\\n' "$2"
+		printf '            %s -o /tmp/live_spec.yaml\n' "$url"
+	} > "$1"
+}
+
+# accepts <name>
+accepts() {
+	if "$gate" "$tmp/Makefile" "$tmp/drift.yaml" >/dev/null 2>&1; then
+		echo "ok: $1"
+	else
+		note "$1 — the gate rejected a compliant pair"
+	fi
+}
+
+# rejects <name> <expected-exit>
+rejects() {
+	local rc=0
+	"$gate" "$tmp/Makefile" "$tmp/drift.yaml" >/dev/null 2>&1 || rc=$?
+	if [ "$rc" -eq "$2" ]; then
+		echo "ok (fail): $1"
+	else
+		note "$1 — expected exit $2, got $rc"
+	fi
+}
+
+mkmake "$tmp/Makefile" "$flags"
+mkflow "$tmp/drift.yaml" "$flags"
+accepts "a compliant pair passes, and a legitimate -L elsewhere does not trip it"
+
+# Each required flag, removed in turn, from each file.
+for missing in "--proto '=https'" '--tlsv1.2' '--max-time 60' '-fsS' '--remove-on-error'; do
+	stripped=${flags/$missing/}
+	mkmake "$tmp/Makefile" "$stripped"
+	mkflow "$tmp/drift.yaml" "$flags"
+	rejects "Makefile dropping ${missing} is caught" 1
+
+	mkmake "$tmp/Makefile" "$flags"
+	mkflow "$tmp/drift.yaml" "$stripped"
+	rejects "drift.yaml dropping ${missing} is caught" 1
+done
+
+# -L, in both spellings and both files.
+mkmake "$tmp/Makefile" "$flags -L"
+mkflow "$tmp/drift.yaml" "$flags"
+rejects "Makefile regaining -L is caught" 1
+
+mkmake "$tmp/Makefile" "${flags/-fsS/-fsSL}"
+mkflow "$tmp/drift.yaml" "$flags"
+rejects "Makefile regaining L inside a bundle is caught" 1
+
+mkmake "$tmp/Makefile" "$flags"
+mkflow "$tmp/drift.yaml" "$flags --location"
+rejects "drift.yaml regaining --location is caught" 1
+
+# The content pin must stay a human edit.
+mkmake "$tmp/Makefile" "$flags" 'sha256sum openapi.yaml > openapi.yaml.sha256'
+mkflow "$tmp/drift.yaml" "$flags"
+rejects "update-spec computing a digest is caught" 1
+
+# The gate must notice when it no longer matches what it guards.
+mkmake "$tmp/Makefile" "$flags"
+mkflow "$tmp/drift.yaml" "$flags"
+printf 'update-spec:\n\tcurl %s -o openapi.yaml\n' "$flags" > "$tmp/Makefile"
+rejects "a spec fetch the gate cannot find is caught" 1
+
+{
+	printf 'update-spec:\n'
+	printf '\tcurl %s \\\n\t\t%s -o openapi.yaml\n' "$flags" "$url"
+	printf '\tcurl %s \\\n\t\t%s -o copy.yaml\n' "$flags" "$url"
+} > "$tmp/Makefile"
+mkflow "$tmp/drift.yaml" "$flags"
+rejects "two spec fetches in one file is caught" 1
+
+# The three ways a naive line-matching gate is fooled. Each of these passed
+# an earlier version of fetch-flags.sh while the live fetch ran unsafely.
+mkflow "$tmp/drift.yaml" "$flags"
+{
+	printf 'SPEC_URL := %s\n' "$url"
+	printf '# Canonical fetch, for reference:\n'
+	printf '#   curl %s %s -o openapi.yaml\n' "$flags" "$url"
+	# The dollar comes from a variable so the fixture carries no quoted
+	# $( ) for the linter to object to. What matters to the test is only
+	# that the recipe line carries no URL for the gate to anchor on.
+	printf 'update-spec:\n\tcurl -L -k -o openapi.yaml %s(SPEC_URL)\n' '$'
+} > "$tmp/Makefile"
+rejects "a commented-out canonical fetch does not vouch for the live one" 1
+
+{
+	printf 'update-spec:\n'
+	printf '\tcurl -o openapi.yaml %s \\\n' "$url"
+	printf '\t\t# flags: %s\n' "$flags"
+} > "$tmp/Makefile"
+rejects "flags demoted to a trailing comment do not count" 1
+
+mkmake "$tmp/Makefile" "$flags"
+{
+	printf 'name: spec-drift\njobs:\n  diff:\n    steps:\n      - run: |\n'
+	printf '          curl %s \\\n' "$flags"
+	printf '            %s -o /tmp/probe.yaml; \\\n' "$url"
+	printf "            curl --insecure --proto '=http' -o /tmp/live_spec.yaml %s\n" "$url"
+} > "$tmp/drift.yaml"
+rejects "a compliant probe does not vouch for an unsafe fetch beside it" 1
+
+# And the two false positives the narrowing removed: the gate must not fire
+# on a -L belonging to another command, nor on a comment documenting its own
+# rule.
+mkflow "$tmp/drift.yaml" "$flags"
+mkmake "$tmp/Makefile" "$flags" 'cp -L /tmp/staged openapi.yaml'
+accepts "a -L on another command in the recipe is not the fetch's"
+
+mkmake "$tmp/Makefile" "$flags"
+printf '\n# NOTE: never regenerate contract.SpecSHA256 with sha256sum.\n' >> "$tmp/Makefile"
+accepts "a comment documenting the digest rule does not trip it"
+
+# Fail closed on its own inputs.
+mkmake "$tmp/Makefile" "$flags"
+rm -f "$tmp/drift.yaml"
+rejects "an unreadable input fails closed" 2
+
+mkflow "$tmp/drift.yaml" "$flags"
+for argc in 0 1 3; do
+	rc=0
+	case $argc in
+	0) "$gate" >/dev/null 2>&1 || rc=$? ;;
+	1) "$gate" "$tmp/Makefile" >/dev/null 2>&1 || rc=$? ;;
+	3) "$gate" "$tmp/Makefile" "$tmp/drift.yaml" extra >/dev/null 2>&1 || rc=$? ;;
+	esac
+	if [ "$rc" -eq 2 ]; then
+		echo "ok (fail): a ${argc}-argument call fails closed"
+	else
+		note "a ${argc}-argument call must exit 2, got $rc"
+	fi
+done
+
+if [ "$fail" -ne 0 ]; then
+	echo "fetch-flags gate self-test FAILED"
+	exit 1
+fi
+echo "ok: fetch-flags gate classifies every case correctly"

--- a/scripts/fetch-flags.sh
+++ b/scripts/fetch-flags.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bruno Venceslau. All rights reserved.
+# Use of this source code is governed by a BSD-2-Clause
+# license that can be found in the LICENSE file.
+#
+# fetch-flags.sh <makefile> <drift-workflow>
+#
+# Asserts the two places that download the vendored OpenAPI spec still carry
+# the supply-chain flags they were given, and still carry no -L.
+#
+# Those flags were reasoned about once, at length, and are enforced by
+# nothing: a future edit could restore -L or drop --remove-on-error and every
+# gate would stay green. The comments explaining them are not a control. This
+# is.
+#
+# It deliberately does NOT police every curl in the repo. go-latest-check and
+# check-version.sh both pass -L legitimately — they parse a string into a
+# variable rather than vendoring bytes to disk, so a redirect costs them
+# nothing. Forbidding -L globally would either break them or teach the next
+# maintainer that this gate is noise to be worked around.
+#
+# It also asserts update-spec does not compute a digest. The content pin is a
+# tripwire only while a human updates contract.SpecSHA256 by hand; a recipe
+# that regenerated it would satisfy the gate on every re-vendor and assert
+# nothing. That decision currently lives in prose, which is exactly the class
+# of thing this script exists to convert into a check.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: fetch-flags.sh <makefile> <drift-workflow>" >&2
+	exit 2
+fi
+
+makefile=$1
+workflow=$2
+
+for f in "$makefile" "$workflow"; do
+	if [ ! -r "$f" ]; then
+		echo "error: $f is not readable" >&2
+		exit 2
+	fi
+done
+
+fail=0
+bad() {
+	echo "error: $1" >&2
+	fail=1
+}
+
+# The spec-fetch invocations: the ones naming the OpenAPI endpoint. Both
+# files must have exactly one, or the shape of this gate no longer matches
+# the thing it guards.
+spec_url='api\.ynab\.com/papi/open_api_spec\.yaml'
+
+# fetches extracts the shell commands that fetch the spec, one per line.
+#
+# It does three things, and each one closes a way the naive version could be
+# fooled. It drops comments, because a commented-out canonical fetch left
+# for reference would otherwise satisfy every flag check while the live
+# recipe ran with -L -k. It joins continuations, because the flags and the
+# URL sit on different physical lines in both files. And it splits on ; and
+# && so that two commands sharing one logical line stay two commands —
+# otherwise a compliant probe fetch could vouch for an unsafe one beside it.
+#
+# Splitting also stops the whole recipe from being treated as the fetch: the
+# update-spec recipe is one continued line end to end, so without this a
+# `cp -L` three commands later reads as the curl passing -L, and a
+# --max-time anywhere in the recipe satisfies the check for the curl.
+#
+# awk rather than sed: joining and splitting both want a newline in the
+# output, and `\n` in a sed replacement is a GNU extension BSD sed rejects.
+fetches() {
+	awk -v url="$spec_url" '
+		/^[[:space:]]*#/ { next }                  # a whole-line comment
+		{ buf = buf $0 }
+		/\\$/ { sub(/\\$/, "", buf); next }        # continuation: keep going
+		{
+			n = split(buf, parts, /;|&&/)
+			for (i = 1; i <= n; i++) {
+				frag = parts[i]
+				sub(/[[:space:]]#.*$/, "", frag)   # a trailing comment
+				if (frag ~ /curl/ && frag ~ url) print frag
+			}
+			buf = ""
+		}
+	' "$1"
+}
+
+for f in "$makefile" "$workflow"; do
+	n=$(fetches "$f" | grep -c . || true)
+	if [ "$n" -ne 1 ]; then
+		bad "$f has $n spec-fetch curl commands, expected exactly 1 — this gate no longer matches what it guards"
+		continue
+	fi
+
+	line=$(fetches "$f")
+
+	for flag in "--proto '=https'" '--tlsv1.2' '-fsS' '--max-time' '--remove-on-error'; do
+		case $line in
+		*"$flag"*) ;;
+		*) bad "$f: the spec fetch no longer passes $flag" ;;
+		esac
+	done
+
+	# -L would let whatever host a Location names supply the bytes. Match the
+	# short form only as a separate word or inside a bundle, so --location and
+	# a bare -L are both caught while, say, --tlsv1.2 is not.
+	case $line in
+	*--location*) bad "$f: the spec fetch passes --location; a redirect must not choose the bytes" ;;
+	esac
+	if printf '%s\n' "$line" | grep -Eq '(^|[[:space:]])-[a-zA-Z]*L'; then
+		bad "$f: the spec fetch passes -L; a redirect must not choose the bytes"
+	fi
+done
+
+# The content pin stays a human decision. Only the recipe's own command
+# lines count: a sed range ending at the next line starting with a letter
+# would sweep in the following comment block, so a comment DOCUMENTING this
+# very rule ("never regenerate SpecSHA256 with sha256sum") would trip the
+# gate and accuse the maintainer of what it says not to do.
+recipe=$(awk '/^update-spec:/ { r = 1; next } r && !/^\t/ { exit } r && !/^[[:space:]]*#/' "$makefile")
+case $recipe in
+*sha256* | *shasum* | *SpecSHA256*) bad "$makefile: update-spec computes a digest; contract.SpecSHA256 must stay a deliberate human edit, or the content pin asserts nothing" ;;
+esac
+
+if [ "$fail" -ne 0 ]; then
+	exit 1
+fi
+echo "ok: the spec-fetch flags and the content-pin boundary are intact"


### PR DESCRIPTION
The flags on the two curls that download the vendored spec were reasoned
about at length and enforced by nothing. A future edit could restore -L or
drop --remove-on-error and every gate would stay green; the comments
explaining them are documentation, not a control. So is the decision that
update-spec must never compute contract.SpecSHA256 itself — a recipe that
regenerated the digest would satisfy the content pin on every re-vendor and
assert nothing at all. Both are now checks.

scripts/fetch-flags.sh asserts that the Makefile's update-spec recipe and
drift.yaml's fetch step each contain exactly one spec-fetch curl, that it
still passes --proto '=https', --tlsv1.2, -fsS, --max-time and
--remove-on-error, and that it passes neither -L nor --location.

Getting at "the fetch" is the whole difficulty, and the first draft got it
wrong in three ways that all had the same root: it matched a joined line of
text rather than a command. Review found working bypasses for each, and
they are now fixtures. Hoisting the URL into a Make variable moved it off
the recipe line, so the gate anchored on a commented-out canonical fetch
left for reference and blessed a live `curl -L -k`. Demoting the flags to a
trailing comment satisfied every substring check. And a compliant probe
fetch sharing one logical line with an unsafe one vouched for it, because
grep -c counted lines. The extractor now drops comments before joining,
joins continuations, and splits on ; and && so each command stands alone.

The same narrowing removed two false positives, also fixtures now: the
whole update-spec recipe is one continued line, so a `cp -L` three commands
later read as the curl passing -L, and a --max-time anywhere in the recipe
satisfied the check for the curl.

The digest check reads only the recipe's own command lines. A sed range
ending at the next line starting with a letter swept in the following
comment block — so a comment DOCUMENTING this very rule ("never regenerate
SpecSHA256 with sha256sum") turned local-ci red and accused the maintainer
of what it says not to do.

awk rather than sed for both: joining and splitting want a newline in the
output, and \n in a sed replacement is a GNU extension BSD sed rejects.
That trap already cost this stack one commit; CI is Linux-only and would
not have caught it either time.

The gate deliberately does not police every curl in the repo.
go-latest-check and check-version.sh both pass -L legitimately — they parse
a string into a variable rather than vendoring bytes to disk, so a redirect
costs them nothing. A repo-wide ban would either break them or teach the
next maintainer that this gate is noise to route around, and a gate people
route around is worse than no gate. A compliant pair with a legitimate -L
beside it is a passing fixture.

It also fails if it can no longer FIND the fetch it guards, in either
direction: zero matches or two. A grep gate's characteristic failure is
passing on everything, and "the file was restructured and my pattern
stopped matching" is how that happens quietly.

fetch-flags-selftest drives 27 hand-written fixtures, no network. Fixtures
are hand-written rather than derived from the real files, because the
gate's whole job is to notice those files changing. An earlier review
injected 11 independent mutations into the gate — an emptied flag loop,
inverted case arms, fail=1 removed from bad(), the -L regex neutered, the
final exit turned into 0 — and all 11 went red.

Both scripts are shellcheck-clean. Wired into local-ci and ci.yaml beside
the other selftests. Tooling only: no Go file, no module byte, no public
surface, and no CHANGELOG line — CONTRIBUTING scopes that to user-visible
changes.

