### PR TITLE
test(contract): pin the spec's inline property enums, dropping a false waiver

### DIFF
--- a/contract_wire_test.go
+++ b/contract_wire_test.go
@@ -66,12 +66,12 @@ var wireBoundsUnenforced = map[[2]string]string{
 // enum type that mirrors it. The Go members come from the same AST scan
 // TestEnumValidTables uses, so neither side is hand-repeated here.
 //
-// Scope, stated because the set is not everything transcribed: the spec also
-// declares four enums inline on properties inside components: — GoalType,
-// GoalFrequency and HybridType, which would pin cleanly today, and
-// DebtTransactionType, whose Go set has eight members against the spec's
-// four, sourced deliberately from docs/v1/research. Pinning the first three
-// and waiving the fourth is a follow-up, not a claim this file already makes.
+// The enums the spec declares inline on properties are pinned separately in
+// wirePropertyEnums. (An earlier revision of this comment waived
+// DebtTransactionType claiming the Go set had eight members against the
+// spec's four — that was false: openapi.yaml's debt_transaction_type on
+// TransactionSummaryBase declares the same eight plus null, which is the
+// in-tree evidence; the untracked research note the claim cited agrees.)
 var wireEnums = map[string]string{
 	"AccountType":                   "AccountType",
 	"SaveAccountType":               "AccountSpecType",
@@ -89,6 +89,57 @@ var wireNullableEnums = map[string]bool{
 	"TransactionClearedStatus":      false,
 	"TransactionFlagColor":          true,
 	"ScheduledTransactionFrequency": false,
+}
+
+// wirePropertyEnums maps every enum the spec declares INLINE on a schema
+// property — the value sets upstream chose not to name, which Go names
+// anyway — to the Go enum type that mirrors it. Properties that $ref a
+// named enum schema are not here: their MEMBER SETS are pinned once in
+// wireEnums, but nothing a $ref property carries is pinned yet — neither
+// which named schema it points at nor a 3.1 sibling keyword beside the
+// $ref. Both slip both tables; one recorded follow-up, not a covered case.
+//
+// One value set appears once per schema that reaches it, directly or
+// through allOf, because that is the set of wire shapes it constrains:
+// goal_type is declared on CategoryBase and inherited by Category;
+// debt_transaction_type is declared on TransactionSummaryBase and inherited
+// three times; frequency is declared on ScheduledTransactionSummaryBase and
+// inherited twice; goal_frequency is declared on SaveCategory and inherited
+// by NewCategory and ExistingCategory.
+var wirePropertyEnums = map[[2]string]string{
+	{"CategoryBase", "goal_type"}:                       "GoalType",
+	{"Category", "goal_type"}:                           "GoalType",
+	{"SaveCategory", "goal_frequency"}:                  "GoalFrequency",
+	{"NewCategory", "goal_frequency"}:                   "GoalFrequency",
+	{"ExistingCategory", "goal_frequency"}:              "GoalFrequency",
+	{"TransactionSummaryBase", "debt_transaction_type"}: "DebtTransactionType",
+	{"TransactionSummary", "debt_transaction_type"}:     "DebtTransactionType",
+	{"TransactionDetail", "debt_transaction_type"}:      "DebtTransactionType",
+	{"HybridTransaction", "debt_transaction_type"}:      "DebtTransactionType",
+	{"HybridTransaction", "type"}:                       "HybridType",
+	{"ScheduledTransactionSummaryBase", "frequency"}:    "Frequency",
+	{"ScheduledTransactionSummary", "frequency"}:        "Frequency",
+	{"ScheduledTransactionDetail", "frequency"}:         "Frequency",
+}
+
+// wireNullablePropertyEnums pins which of those inline enums admit a bare
+// null. The Go side models that through the type — *GoalType and
+// *DebtTransactionType on reads — so a change here is a change to what
+// those types must be.
+var wireNullablePropertyEnums = map[[2]string]bool{
+	{"CategoryBase", "goal_type"}:                       true,
+	{"Category", "goal_type"}:                           true,
+	{"SaveCategory", "goal_frequency"}:                  false,
+	{"NewCategory", "goal_frequency"}:                   false,
+	{"ExistingCategory", "goal_frequency"}:              false,
+	{"TransactionSummaryBase", "debt_transaction_type"}: true,
+	{"TransactionSummary", "debt_transaction_type"}:     true,
+	{"TransactionDetail", "debt_transaction_type"}:      true,
+	{"HybridTransaction", "debt_transaction_type"}:      true,
+	{"HybridTransaction", "type"}:                       false,
+	{"ScheduledTransactionSummaryBase", "frequency"}:    false,
+	{"ScheduledTransactionSummary", "frequency"}:        false,
+	{"ScheduledTransactionDetail", "frequency"}:         false,
 }
 
 // TestContractWireBounds diffs the transcribed maxLength constants against
@@ -139,6 +190,10 @@ func TestContractWireEnums(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, schemas.Enums, len(wireEnums),
 		"every schema-level enum must be mapped, and nothing else")
+	// A missing key in a map[...]bool reads as false, so without this a
+	// forgotten nullability row would silently assert non-nullable.
+	require.Len(t, wireNullableEnums, len(wireEnums),
+		"every mapped enum needs an explicit nullability row")
 
 	goEnums := scanEnumConsts(t)
 
@@ -157,6 +212,11 @@ func TestContractWireEnums(t *testing.T) {
 
 		hasNull, ok := schemas.NullableEnum(specName)
 		require.True(t, ok)
+		// Contains before Equal: with equal cardinality already pinned,
+		// membership makes the two tables bijective — a miskeyed row can
+		// no longer read as zero-value false while its orphan sits unread.
+		require.Contains(t, wireNullableEnums, specName,
+			"every mapped enum needs an explicit nullability row under its own key")
 		require.Equal(t, wireNullableEnums[specName], hasNull,
 			"%s changed nullability upstream — the Go type models that as a pointer or "+
 				"Optional, so this is a type change, not a value change", specName)
@@ -165,5 +225,51 @@ func TestContractWireEnums(t *testing.T) {
 	for _, e := range schemas.Enums {
 		require.Contains(t, wireEnums, e.Schema,
 			"spec declares an enum on %s that no Go type mirrors: %q", e.Schema, e.Values)
+	}
+}
+
+// TestContractWirePropertyEnums does for the spec's inline property enums
+// what TestContractWireEnums does for the named ones: diffs the Go member
+// sets against the spec's, both ways, and pins which admit a null.
+func TestContractWirePropertyEnums(t *testing.T) {
+	t.Parallel()
+
+	schemas, err := contract.ScanSchemas("openapi.yaml")
+	require.NoError(t, err)
+	require.Len(t, schemas.PropEnums, len(wirePropertyEnums),
+		"every inline property enum must be mapped, and nothing else")
+	// Same zero-value trap as the named-enum tables: unlisted must be
+	// impossible, not a silent false.
+	require.Len(t, wireNullablePropertyEnums, len(wirePropertyEnums),
+		"every mapped pair needs an explicit nullability row")
+
+	goEnums := scanEnumConsts(t)
+
+	for key, goName := range wirePropertyEnums {
+		specValues, ok := schemas.PropEnumFor(key[0], key[1])
+		require.True(t, ok, "spec no longer declares an inline enum on %s.%s", key[0], key[1])
+
+		goValues, ok := goEnums[goName]
+		require.True(t, ok, "no Go enum named %s; the mapping is stale", goName)
+
+		require.ElementsMatch(t, specValues, goValues,
+			"%s does not match the spec's inline enum on %s.%s — upstream added or removed "+
+				"a wire value", goName, key[0], key[1])
+
+		hasNull, ok := schemas.NullablePropEnum(key[0], key[1])
+		require.True(t, ok)
+		// Same bijectivity move as the named tables: Len pins cardinality,
+		// Contains pins membership, together no key can drift.
+		require.Contains(t, wireNullablePropertyEnums, key,
+			"every mapped pair needs an explicit nullability row under its own key")
+		require.Equal(t, wireNullablePropertyEnums[key], hasNull,
+			"%s.%s changed nullability upstream — the Go type models that as a pointer, "+
+				"so this is a type change, not a value change", key[0], key[1])
+	}
+
+	for _, e := range schemas.PropEnums {
+		require.Contains(t, wirePropertyEnums, [2]string{e.Schema, e.Property},
+			"spec declares an inline enum on %s.%s that no Go type mirrors: %q",
+			e.Schema, e.Property, e.Values)
 	}
 }

--- a/internal/contract/schema.go
+++ b/internal/contract/schema.go
@@ -30,15 +30,27 @@ type Enum struct {
 	HasNull bool
 }
 
-// Schemas is the resolved view of the components: section.
-type Schemas struct {
-	Bounds []Bound
-	Enums  []Enum
+// PropEnum is one enum the spec declares inline on a schema property,
+// including the ones a schema inherits through allOf. It splits a bare
+// null out of the scalar members exactly as Enum does, and for the same
+// reason.
+type PropEnum struct {
+	Schema   string
+	Property string
+	Values   []string
+	HasNull  bool
 }
 
-// ScanSchemas reads the maxLength bounds and schema-level enum sets out of
-// the vendored spec's components: section — the half ScanSpec is
-// deliberately blind to.
+// Schemas is the resolved view of the components: section.
+type Schemas struct {
+	Bounds    []Bound
+	Enums     []Enum
+	PropEnums []PropEnum
+}
+
+// ScanSchemas reads the maxLength bounds and enum sets — schema-level and
+// property-level — out of the vendored spec's components: section, the half
+// ScanSpec is deliberately blind to.
 //
 // Unlike ScanSpec this parses rather than scans lines. ScanSpec can afford a
 // line scanner because the paths: layout it reads is strictly regular and it
@@ -53,9 +65,11 @@ type Schemas struct {
 // the parser costs no new module edge and removes all four classes rather
 // than narrowing them.
 //
-// Bounds include those reached through allOf, which is the set the wire
-// actually enforces: NewTransaction declares only import_id itself and
-// inherits payee_name and memo from SaveTransactionWithOptionalFields.
+// Bounds and property enums include those reached through allOf, which is
+// the set the wire actually enforces: NewTransaction declares only import_id
+// itself and inherits payee_name and memo from
+// SaveTransactionWithOptionalFields, and TransactionDetail inherits
+// debt_transaction_type from TransactionSummaryBase two hops up.
 func ScanSchemas(path string) (*Schemas, error) {
 	doc, err := openapi3.NewLoader().LoadFromFile(path)
 	if err != nil {
@@ -70,8 +84,14 @@ func ScanSchemas(path string) (*Schemas, error) {
 		if ref.Value == nil {
 			continue
 		}
-		collectBounds(name, ref.Value, &out, map[*openapi3.Schema]bool{})
-		if e, ok := enumOf(name, ref.Value); ok {
+		if err := collectProps(name, ref.Value, &out, map[*openapi3.Schema]bool{}); err != nil {
+			return nil, err
+		}
+		e, ok, err := enumOf(name, ref.Value)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			out.Enums = append(out.Enums, e)
 		}
 	}
@@ -85,52 +105,116 @@ func ScanSchemas(path string) (*Schemas, error) {
 		return out.Bounds[i].Property < out.Bounds[j].Property
 	})
 	sort.Slice(out.Enums, func(i, j int) bool { return out.Enums[i].Schema < out.Enums[j].Schema })
+	// Stable, because (Schema, Property) can tie: two allOf branches may
+	// declare the same property, and both records are kept. Stability
+	// preserves the deterministic branch order, so equal keys cannot
+	// reshuffle between runs.
+	sort.SliceStable(out.PropEnums, func(i, j int) bool {
+		if out.PropEnums[i].Schema != out.PropEnums[j].Schema {
+			return out.PropEnums[i].Schema < out.PropEnums[j].Schema
+		}
+		return out.PropEnums[i].Property < out.PropEnums[j].Property
+	})
 	return &out, nil
 }
 
-// collectBounds records every maxLength on s and on the schemas it composes
-// through allOf, attributing each to the named schema that reaches it. The
-// seen set guards against a cyclic allOf.
-func collectBounds(name string, s *openapi3.Schema, out *Schemas, seen map[*openapi3.Schema]bool) {
+// collectProps records every maxLength and every property-level enum on s
+// and on the schemas it composes through allOf, attributing each to the
+// named schema that reaches it. The seen set guards against a cyclic allOf
+// and keeps a diamond (two branches composing the same base) from recording
+// the base's properties twice.
+//
+// The walk reads one property level deep, matching the bounds' scope: an
+// enum (or maxLength) on an array's items, inside a nested inline object,
+// or under a property's own composition keywords is deliberately out of
+// scope, and a fixture pins each of the three shapes. The vendored spec
+// declares nothing there today; if upstream starts to, extending the walk
+// is the fix — silently widening the claim is not.
+func collectProps(name string, s *openapi3.Schema, out *Schemas, seen map[*openapi3.Schema]bool) error {
 	if s == nil || seen[s] {
-		return
+		return nil
 	}
 	seen[s] = true
 
 	for prop, ref := range s.Properties {
-		if ref.Value == nil || ref.Value.MaxLength == nil {
+		if ref.Value == nil {
 			continue
 		}
-		// The spec's bounds are small (36..500). Anything past MaxInt is
-		// not a length this library could enforce anyway, and narrowing it
-		// silently would turn an absurd bound into a plausible one.
-		if n := *ref.Value.MaxLength; n <= math.MaxInt {
-			out.Bounds = append(out.Bounds, Bound{name, prop, int(n)})
+		if ref.Value.MaxLength != nil {
+			// The spec's bounds are small (36..500). Anything past MaxInt is
+			// not a length this library could enforce anyway, and narrowing
+			// it silently would turn an absurd bound into a plausible one.
+			if n := *ref.Value.MaxLength; n <= math.MaxInt {
+				out.Bounds = append(out.Bounds, Bound{name, prop, int(n)})
+			}
+		}
+		// Only enums declared inline on the property. A property that
+		// $refs a named enum schema (cleared, flag_color, …) resolves to
+		// that schema's members here, and those MEMBER SETS are pinned
+		// once at schema level — re-recording them per property would
+		// assert the same fact dozens of times and drown the inline ones,
+		// which are the sets upstream chose not to name and Go names
+		// anyway. What the cut does NOT preserve is anything else the
+		// $ref property carries: a $ref retargeted from one named enum to
+		// another is invisible because THIS guard skips every $ref-bearing
+		// property, and so is a 3.1-style sibling keyword beside the $ref
+		// (this spec declares OpenAPI 3.1, where a sibling enum is
+		// meaningful; the loader overlays it onto ref.Value — measured —
+		// so closing that gap is local to this walk, not a loader
+		// problem). Both shapes are tracked as one follow-up rather than
+		// implied covered.
+		if ref.Ref == "" && len(ref.Value.Enum) > 0 {
+			values, hasNull, err := splitEnum(ref.Value.Enum)
+			if err != nil {
+				return fmt.Errorf("contract: %s.%s: %w", name, prop, err)
+			}
+			out.PropEnums = append(out.PropEnums, PropEnum{name, prop, values, hasNull})
 		}
 	}
 	for _, branch := range s.AllOf {
-		collectBounds(name, branch.Value, out, seen)
+		if err := collectProps(name, branch.Value, out, seen); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // enumOf returns the enum declared directly on a named schema, splitting a
-// bare null out of the scalar members. Property-level enums are not
-// collected: the Go types this pins are named wire enums, and the four
-// inline ones under components: are a separate, deliberate scope decision
-// recorded by the caller.
-func enumOf(name string, s *openapi3.Schema) (Enum, bool) {
+// bare null out of the scalar members. Enums on properties are PropEnums,
+// collected by collectProps.
+func enumOf(name string, s *openapi3.Schema) (Enum, bool, error) {
 	if len(s.Enum) == 0 {
-		return Enum{}, false
+		return Enum{}, false, nil
 	}
-	e := Enum{Schema: name}
-	for _, v := range s.Enum {
+	values, hasNull, err := splitEnum(s.Enum)
+	if err != nil {
+		return Enum{}, false, fmt.Errorf("contract: %s: %w", name, err)
+	}
+	return Enum{Schema: name, Values: values, HasNull: hasNull}, true, nil
+}
+
+// splitEnum separates an enum's scalar members from a bare null member.
+// The Go enums model nullability through the type, not through a sentinel
+// value, so the two are compared apart.
+//
+// Anything else is refused rather than rendered: every Go mirror is a
+// string enum, and fmt.Sprint would collapse a bare true and a quoted
+// "true" — or 1, 1.0 and "1" — into one pinned spelling, letting two specs
+// that differ on the wire produce identical pins. A gate that coerces is a
+// gate that can lie.
+func splitEnum(members []any) (values []string, hasNull bool, err error) {
+	for _, v := range members {
 		if v == nil {
-			e.HasNull = true
+			hasNull = true
 			continue
 		}
-		e.Values = append(e.Values, fmt.Sprint(v))
+		s, ok := v.(string)
+		if !ok {
+			return nil, false, fmt.Errorf("non-string enum member %v (%T)", v, v)
+		}
+		values = append(values, s)
 	}
-	return e, true
+	return values, hasNull, nil
 }
 
 // BoundFor returns the maxLength the spec declares for schema.property.
@@ -157,6 +241,31 @@ func (s *Schemas) EnumFor(schema string) ([]string, bool) {
 func (s *Schemas) NullableEnum(schema string) (bool, bool) {
 	for _, e := range s.Enums {
 		if e.Schema == schema {
+			return e.HasNull, true
+		}
+	}
+	return false, false
+}
+
+// PropEnumFor returns the scalar enum members the spec declares on
+// schema.property, directly or through allOf. When two allOf branches
+// declare the same pair, the first record in branch order wins here — the
+// wire test's completeness count is what makes such a duplicate loud.
+func (s *Schemas) PropEnumFor(schema, property string) ([]string, bool) {
+	for _, e := range s.PropEnums {
+		if e.Schema == schema && e.Property == property {
+			return e.Values, true
+		}
+	}
+	return nil, false
+}
+
+// NullablePropEnum reports whether the spec's enum on schema.property
+// admits a bare null. On a duplicate pair the first record in branch
+// order wins, exactly as in PropEnumFor.
+func (s *Schemas) NullablePropEnum(schema, property string) (bool, bool) {
+	for _, e := range s.PropEnums {
+		if e.Schema == schema && e.Property == property {
 			return e.HasNull, true
 		}
 	}

--- a/internal/contract/schema_test.go
+++ b/internal/contract/schema_test.go
@@ -25,6 +25,8 @@ func TestContractScanSchemas(t *testing.T) {
 
 	require.Len(t, s.Bounds, 17, "11 declared inline, 6 more reached through allOf")
 	require.Len(t, s.Enums, 5, "the spec declares 5 schema-level enums")
+	require.Len(t, s.PropEnums, 13,
+		"5 enums declared inline on properties, reached by 13 (schema, property) pairs through allOf")
 
 	// allOf resolution is the reason this parses rather than scans lines:
 	// NewTransaction declares only import_id and inherits the other two.
@@ -63,6 +65,30 @@ func TestContractScanSchemas(t *testing.T) {
 
 	_, ok = s.EnumFor("NoSuchSchema")
 	require.False(t, ok)
+
+	_, ok = s.NullableEnum("NoSuchSchema")
+	require.False(t, ok, "a nullability miss reports false, not a zero value")
+
+	// Property-level enums: declared inline on CategoryBase, inherited by
+	// Category through allOf — both spellings must resolve.
+	for _, schema := range []string{"CategoryBase", "Category"} {
+		values, ok := s.PropEnumFor(schema, "goal_type")
+		require.True(t, ok, "%s.goal_type must resolve", schema)
+		require.ElementsMatch(t, []string{"TB", "TBD", "MF", "NEED", "DEBT"}, values)
+
+		hasNull, ok := s.NullablePropEnum(schema, "goal_type")
+		require.True(t, ok)
+		require.True(t, hasNull, "goal_type admits a bare null")
+	}
+
+	// A property that $refs a named enum schema is NOT a property enum:
+	// cleared resolves to TransactionClearedStatus's members, but that set
+	// is pinned once at schema level.
+	_, ok = s.PropEnumFor("NewTransaction", "cleared")
+	require.False(t, ok, "a $ref to a named enum is pinned at schema level, not per property")
+
+	_, ok = s.NullablePropEnum("NewTransaction", "cleared")
+	require.False(t, ok)
 }
 
 // TestContractScanSchemasShapes drives the parser over hand-written
@@ -75,10 +101,11 @@ func TestContractScanSchemasShapes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		doc        string
-		wantBounds []contract.Bound
-		wantEnums  int
+		name          string
+		doc           string
+		wantBounds    []contract.Bound
+		wantEnums     int
+		wantPropEnums []contract.PropEnum
 	}{{
 		name: "block style",
 		doc: `openapi: 3.1.0
@@ -190,9 +217,191 @@ components:
       properties:
         kind:
           type: string
-          enum: [inline]
+          enum: [inline, null]
 `,
 		wantEnums: 1,
+		wantPropEnums: []contract.PropEnum{
+			{Schema: "Thing", Property: "kind", Values: []string{"inline"}, HasNull: true},
+		},
+	}, {
+		name: "a property that $refs a named enum is not re-recorded per property",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Colors:
+      type: string
+      enum: [red, ""]
+    Thing:
+      type: object
+      properties:
+        color:
+          $ref: "#/components/schemas/Colors"
+`,
+		wantEnums: 1,
+	}, {
+		name: "allOf contributes the branch's inline enums to the composing schema",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Base:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [a, b]
+    Derived:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+        - type: object
+          properties:
+            extra:
+              type: string
+              enum: [x]
+`,
+		wantPropEnums: []contract.PropEnum{
+			{Schema: "Base", Property: "kind", Values: []string{"a", "b"}},
+			{Schema: "Derived", Property: "extra", Values: []string{"x"}},
+			{Schema: "Derived", Property: "kind", Values: []string{"a", "b"}},
+		},
+	}, {
+		name: "a diamond allOf records the shared base once per reaching schema",
+		// Derived composes Base through two middle schemas. The seen set
+		// must dedupe the second arrival, so Derived carries ONE kind
+		// entry — and the two-hop chain itself is proven here, in a
+		// fixture a re-vendor cannot change, not only through the real
+		// spec's TransactionDetail.
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Base:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [a, b]
+    Mid1:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+    Mid2:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+    Derived:
+      allOf:
+        - $ref: "#/components/schemas/Mid1"
+        - $ref: "#/components/schemas/Mid2"
+`,
+		wantPropEnums: []contract.PropEnum{
+			{Schema: "Base", Property: "kind", Values: []string{"a", "b"}},
+			{Schema: "Derived", Property: "kind", Values: []string{"a", "b"}},
+			{Schema: "Mid1", Property: "kind", Values: []string{"a", "b"}},
+			{Schema: "Mid2", Property: "kind", Values: []string{"a", "b"}},
+		},
+	}, {
+		name: "an items enum is out of scope, like an items bound",
+		// The walk reads one property level, for enums exactly as for
+		// bounds. This pins the cut as a decision: if upstream ever
+		// declares an enum on an array's items, extending the walk is
+		// the fix — this fixture failing is how that conversation starts.
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        legs:
+          type: array
+          items:
+            type: string
+            enum: [x, y]
+`,
+	}, {
+		name: "a nested inline object's enum is out of scope, one level deep only",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        nested:
+          type: object
+          properties:
+            inner:
+              type: string
+              enum: [x, y]
+`,
+	}, {
+		name: "an enum or bound under a property's own oneOf is out of scope",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        kind:
+          oneOf:
+            - type: string
+              enum: [x, y]
+              maxLength: 5
+            - type: string
+`,
+	}, {
+		name: "an enum of only null has no scalar members",
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        kind:
+          type:
+            - string
+            - "null"
+          enum: [null]
+`,
+		wantPropEnums: []contract.PropEnum{
+			{Schema: "Thing", Property: "kind", HasNull: true},
+		},
+	}, {
+		name: "the same property declared by two branches records twice",
+		// allOf means BOTH constraint sets apply; recording both is the
+		// honest reading, and the completeness Len in the wire test is
+		// what turns the duplicate into a loud failure there.
+		doc: `openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      allOf:
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum: [a]
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum: [b]
+`,
+		wantPropEnums: []contract.PropEnum{
+			{Schema: "Thing", Property: "kind", Values: []string{"a"}},
+			{Schema: "Thing", Property: "kind", Values: []string{"b"}},
+		},
 	}}
 
 	for _, tc := range tests {
@@ -206,6 +415,7 @@ components:
 			require.NoError(t, err)
 			require.Equal(t, tc.wantBounds, s.Bounds)
 			require.Len(t, s.Enums, tc.wantEnums)
+			require.Equal(t, tc.wantPropEnums, s.PropEnums)
 		})
 	}
 }
@@ -230,4 +440,62 @@ paths: {}
 	_, err = contract.ScanSchemas(path)
 	require.ErrorContains(t, err, "no component schemas",
 		"a spec with no schemas must fail closed, not report an empty set")
+
+	// A non-string member is refused, not rendered: fmt.Sprint would
+	// collapse 1, 1.0 and "1" into one pinned spelling, and two specs
+	// that differ on the wire would pin identically.
+	path = filepath.Join(t.TempDir(), "numeric-prop.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        kind:
+          type: integer
+          enum: [1, 2]
+`), 0o600))
+	_, err = contract.ScanSchemas(path)
+	require.ErrorContains(t, err, "non-string enum member")
+	require.ErrorContains(t, err, "Thing.kind", "the failure must name the pair")
+
+	path = filepath.Join(t.TempDir(), "numeric-schema.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Level:
+      type: integer
+      enum: [1, 2]
+`), 0o600))
+	_, err = contract.ScanSchemas(path)
+	require.ErrorContains(t, err, "non-string enum member")
+	require.ErrorContains(t, err, "Level", "the failure must name the schema")
+
+	// The same refusal must survive the allOf recursion: a bad member
+	// reached only through a composed branch is attributed to the
+	// composing schema, not silently dropped from the pinned set — a
+	// mutation swallowing the recursive error passed the suite before
+	// this fixture existed.
+	path = filepath.Join(t.TempDir(), "numeric-allof.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`openapi: 3.1.0
+info: {title: t, version: "1"}
+paths: {}
+components:
+  schemas:
+    Derived:
+      allOf:
+        - type: object
+          properties:
+            level:
+              type: integer
+              enum: [1, 2]
+`), 0o600))
+	_, err = contract.ScanSchemas(path)
+	require.ErrorContains(t, err, "non-string enum member")
+	require.ErrorContains(t, err, "Derived.level",
+		"the failure must name the composing schema's pair")
 }


### PR DESCRIPTION
## Summary

Pins the **five enum value sets the spec declares inline on schema properties** — `goal_type`, `goal_frequency`, `debt_transaction_type`, `type` (hybrid), `frequency` — to the Go enums that mirror them (`GoalType`, `GoalFrequency`, `DebtTransactionType`, `HybridType`, `Frequency`), in both directions, with nullability pinned per pair. This closes the property-level half of the wire-constant contract that #55 left as a follow-up.

Along the way it **drops a false waiver**: the recorded follow-up said to waive `DebtTransactionType` because "the Go set has eight members against the spec's four". Measured, that claim is false — `openapi.yaml`'s `debt_transaction_type` on `TransactionSummaryBase` declares the same eight members plus `null`. The comment that carried the claim now records the correction instead of rewriting history.

## What changed

| File | Change |
|---|---|
| `internal/contract/schema.go` | `ScanSchemas` now collects property-level inline enums in the same allOf-attributing walk as the bounds (`collectProps`), with accessors `PropEnumFor` / `NullablePropEnum`. `splitEnum` refuses non-string members instead of `fmt.Sprint`-coercing them. |
| `contract_wire_test.go` | New `wirePropertyEnums` (13 pairs → 5 Go enums) and `wireNullablePropertyEnums` tables + `TestContractWirePropertyEnums`, asserting both directions and completeness. Nullability tables are now provably bijective with their mapping tables (`require.Len` + per-key `require.Contains`). |
| `internal/contract/schema_test.go` | Nine new fixtures: diamond allOf, items / nested-object / property-`oneOf` scope cuts, only-null member, duplicate property across branches, and non-string rejection at property, schema, and allOf-recursion depth. |

## Scope, stated

- **Properties that `$ref` a named enum schema are not re-pinned** — their member sets are already pinned once in `wireEnums`. Without the cut the walk reports 37 (schema, property) pairs, 24 of them `$ref`s to the five named schemas; with it, 13 inline pairs over 5 value sets.
- **What the cut does not cover is stated, not implied away**: nothing pins what a `$ref` property carries — neither its target (a retargeted `$ref` slips both tables) nor an OpenAPI 3.1 sibling keyword beside it (measured: kin-openapi overlays the sibling onto `ref.Value`; the walk's own guard is what skips it). Both shapes are one recorded follow-up.
- The walk reads **one property level deep**, matching the bounds' scope — items, nested inline objects, and property-level composition keywords are out of scope, each pinned by a failing-fixture tripwire.

## Adversarial review (4 rounds, 3 personas each)

| Round | Key finding | Fix |
|---|---|---|
| 1 | False count in draft message; nullability zero-value trap; unproven `seen` guard; `fmt.Sprint` type coercion | Count corrected; parity `Len`; diamond fixture; non-string rejection |
| 2 | `Len` alone still blesses a *miskeyed* nullability row; error swallowed in allOf recursion survived mutation | Per-key `require.Contains` (bijectivity); allOf-error fixture |
| 3 | Comment claimed "the loader discards" the 3.1 sibling — measured false (it overlays onto `ref.Value`) | Mechanism claim corrected to the measured behavior |
| 4 | — | APPROVE / GO / PASS; every mechanism claim independently reproduced |

Final mutation campaign: every drift-detecting mutation on the Go enums, the tables, and the scanner dies; the only survivor is an equivalent mutant (key swap between two same-valued rows).

## Testing

- `make local-ci` exit 0; coverage **97.1%** (up from 97.0% baseline — previously stranded error paths now exercised).
- Test-only change: `internal/contract` is internal, the public Go surface is unchanged, so no `CHANGELOG` entry per `CONTRIBUTING`'s user-visible scope rule.
